### PR TITLE
frontend: load pool denom dynamically; drop dead pyth fields

### DIFF
--- a/frontend/src/components/Commit.tsx
+++ b/frontend/src/components/Commit.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, Typography, TextField, Button, Box, Alert, Tabs, Tab
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CommitTracker from './CommitTracker';
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
-import { DEFAULT_CHAIN_CONFIG } from '../types/FrontendTypes';
+import { DEFAULT_CHAIN_CONFIG, getBluechipDenom } from '../types/FrontendTypes';
 
 interface CommitProps {
     client: SigningCosmWasmClient | null;
@@ -36,6 +36,12 @@ const Commit = ({ client, address }: CommitProps) => {
                 return;
             }
             const amountInMicroUnits = Math.floor(amountVal * 1_000_000).toString();
+
+            // Pool denom is configurable per-pool; read it from the pool's pair {} query
+            // rather than assuming DEFAULT_CHAIN_CONFIG.nativeDenom.
+            const pairInfo = await client.queryContractSmart(targetContractAddress, { pair: {} });
+            const bluechipDenom = getBluechipDenom(pairInfo.asset_infos) ?? DEFAULT_CHAIN_CONFIG.nativeDenom;
+
             const thresholdStatus = await client.queryContractSmart(targetContractAddress, {
                 is_fully_commited: {}
             });
@@ -47,7 +53,7 @@ const Commit = ({ client, address }: CommitProps) => {
             const commitMsg = {
                 asset: {
                     info: {
-                        bluechip: { denom: DEFAULT_CHAIN_CONFIG.nativeDenom }
+                        bluechip: { denom: bluechipDenom }
                     },
                     amount: amountInMicroUnits
                 },
@@ -62,7 +68,7 @@ const Commit = ({ client, address }: CommitProps) => {
                 commit: commitMsg
             };
 
-            const funds = [{ denom: DEFAULT_CHAIN_CONFIG.nativeDenom, amount: amountInMicroUnits }];
+            const funds = [{ denom: bluechipDenom, amount: amountInMicroUnits }];
 
             console.log('Sending commit message:', JSON.stringify(msg, null, 2));
             console.log('With funds:', funds);

--- a/frontend/src/components/CreatePool.tsx
+++ b/frontend/src/components/CreatePool.tsx
@@ -80,8 +80,10 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
                         creator_token_address: address, // Placeholder, will be set by factory
                         commit_amount_for_threshold: DEFAULT_CONFIG.commitAmountForThreshold,
                         commit_limit_usd: DEFAULT_CONFIG.commitThresholdUsd,
-                        pyth_contract_addr_for_conversions: import.meta.env.VITE_ORACLE_ADDRESS || 'oracle_address_placeholder',
-                        pyth_atom_usd_price_feed_id: 'ATOM_USD',
+                        // Schema requires these strings but the factory ignores them and
+                        // uses its own stored pyth config (set at factory instantiation).
+                        pyth_contract_addr_for_conversions: '',
+                        pyth_atom_usd_price_feed_id: '',
                         max_bluechip_lock_per_pool: DEFAULT_CONFIG.maxBluechipLock,
                         creator_excess_liquidity_lock_days: DEFAULT_CONFIG.creatorExcessLockDays,
                         is_standard_pool: isStandardPool


### PR DESCRIPTION
Commit.tsx now queries the pool's pair {} and picks the bluechip denom from asset_infos, matching the pattern already used in Liquidity.tsx. This removes the assumption that every pool uses the chain default denom, which stopped being true once bluechip_denom became configurable.

CreatePool.tsx no longer sends placeholder pyth values. The factory reads pyth_contract_addr_for_conversions and pyth_atom_usd_price_feed_id from its own stored config, not from the CreatePool message, so sending 'ATOM_USD' or 'oracle_address_placeholder' was misleading.