### PR TITLE
H4: enforce ATOM/bluechip pair on anchor pool

### DIFF
--- a/deploy_full_stack_mock_oracle.sh
+++ b/deploy_full_stack_mock_oracle.sh
@@ -170,6 +170,7 @@ FACTORY_INIT=$(cat <<EOF
   "atom_bluechip_anchor_pool_address": "$ALICE_ADDR",
   "bluechip_mint_contract_address": "$ECON_ADDR",
   "bluechip_denom": "ubluechip",
+  "atom_denom": "uatom",
   "standard_pool_creation_fee_usd": "1000000"
 }
 EOF

--- a/factory/src/execute/config.rs
+++ b/factory/src/execute/config.rs
@@ -38,6 +38,23 @@ pub(crate) fn validate_factory_config(
             "bluechip_denom must be non-empty",
         )));
     }
+    // `atom_denom` is the bank denom for the non-bluechip side of the
+    // ATOM/bluechip anchor pool. Required at instantiate so SetAnchorPool
+    // can enforce that the anchor pool actually references it. Empty would
+    // either lock SetAnchorPool out indefinitely or — worse, if the empty
+    // check were skipped — let the admin point the anchor at any bluechip/X
+    // pool with no relation to the Pyth ATOM/USD feed.
+    if config.atom_denom.trim().is_empty() {
+        return Err(ContractError::Std(StdError::generic_err(
+            "atom_denom must be non-empty (e.g. \"uatom\" on Cosmos Hub, or the chain's \
+             IBC-wrapped atom denom). Set this before instantiate or via ProposeConfigUpdate.",
+        )));
+    }
+    if config.atom_denom == config.bluechip_denom {
+        return Err(ContractError::Std(StdError::generic_err(
+            "atom_denom must differ from bluechip_denom",
+        )));
+    }
     Ok(())
 }
 

--- a/factory/src/execute/oracle.rs
+++ b/factory/src/execute/oracle.rs
@@ -225,13 +225,44 @@ pub fn execute_set_anchor_pool(
 
     let factory_config = FACTORYINSTANTIATEINFO.load(deps.storage)?;
     let canonical = &factory_config.bluechip_denom;
-    let has_canonical_bluechip = pool_details.pool_token_info.iter().any(|t| {
-        matches!(t, crate::asset::TokenType::Native { denom } if denom == canonical)
-    });
-    if !has_canonical_bluechip {
+    let atom_denom = &factory_config.atom_denom;
+
+    // Defense for old serialized records that round-trip with an empty
+    // `atom_denom` via the field's `#[serde(default)]`. New deployments
+    // get this checked at instantiate (`validate_factory_config`); the
+    // gate here covers the migration window.
+    if atom_denom.trim().is_empty() {
+        return Err(ContractError::Std(StdError::generic_err(
+            "atom_denom is not configured; propose a factory config update setting \
+             `atom_denom` (e.g. \"uatom\" or your chain's IBC-wrapped atom denom) \
+             before calling SetAnchorPool.",
+        )));
+    }
+
+    // Strict shape: the anchor MUST be a Native/Native pair of exactly
+    // (bluechip_denom, atom_denom) — order doesn't matter. Anything
+    // else (bluechip + arbitrary IBC denom, bluechip + CW20, atom +
+    // CW20, etc.) is rejected so a compromised admin key can't point
+    // the anchor at a pool whose price has no relation to the Pyth
+    // ATOM/USD feed the rest of the oracle math depends on.
+    use crate::asset::TokenType;
+    let denoms: Vec<&str> = pool_details
+        .pool_token_info
+        .iter()
+        .filter_map(|t| match t {
+            TokenType::Native { denom } => Some(denom.as_str()),
+            TokenType::CreatorToken { .. } => None,
+        })
+        .collect();
+
+    let valid_pair = denoms.len() == 2
+        && ((denoms[0] == canonical && denoms[1] == atom_denom)
+            || (denoms[0] == atom_denom && denoms[1] == canonical));
+    if !valid_pair {
         return Err(ContractError::Std(StdError::generic_err(format!(
-            "Anchor pool must include the canonical bluechip denom \"{}\" on one side",
-            canonical
+            "Anchor pool must be a Native/Native pair of exactly (bluechip \"{}\", \
+             atom \"{}\") in either order; got pool with assets {:?}",
+            canonical, atom_denom, pool_details.pool_token_info
         ))));
     }
 

--- a/factory/src/state.rs
+++ b/factory/src/state.rs
@@ -172,6 +172,27 @@ pub struct FactoryInstantiate {
     /// having every downstream oracle/commit path treat that denom's
     /// balance as real bluechip.
     pub bluechip_denom: String,
+    /// Bank denom for the asset paired against bluechip in the
+    /// ATOM/bluechip anchor pool. On Cosmos Hub this is `"uatom"`
+    /// directly; on other chains it's the IBC-wrapped denom hash
+    /// (e.g. `"ibc/27394FB..."`). Pinned at factory instantiate time.
+    /// `execute_set_anchor_pool` enforces that the anchor pool's
+    /// non-bluechip side matches this value exactly, preventing the
+    /// admin (or a compromised admin key) from pointing the anchor at
+    /// a bluechip/<arbitrary> standard pool whose price has no relation
+    /// to the configured Pyth ATOM/USD feed.
+    ///
+    /// Non-empty at instantiate; tunable via the standard 48h
+    /// `ProposeConfigUpdate` flow (e.g. if the chain swaps the
+    /// IBC channel underlying the atom denom).
+    ///
+    /// `#[serde(default)]` keeps old serialized factory records
+    /// (instantiated pre-this-field) deserializing — they round-trip
+    /// with an empty string, and `execute_set_anchor_pool` rejects
+    /// with a clear "atom_denom not configured" error pointing at
+    /// `ProposeConfigUpdate` until the operator backfills it.
+    #[serde(default)]
+    pub atom_denom: String,
     /// USD-denominated fee (6 decimals: 1_000_000 = $1.00) charged on
     /// every `CreateStandardPool` call. Paid in ubluechip — the handler
     /// converts USD → bluechip via the internal oracle at call time. If

--- a/factory/src/testing/audit_tests.rs
+++ b/factory/src/testing/audit_tests.rs
@@ -67,6 +67,7 @@ fn default_factory_config() -> FactoryInstantiate {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     }
 }

--- a/factory/src/testing/oracle_mock_test.rs
+++ b/factory/src/testing/oracle_mock_test.rs
@@ -40,6 +40,7 @@ fn default_init() -> FactoryInstantiate {
         atom_bluechip_anchor_pool_address: addr("unused_anchor"),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     }
 }

--- a/factory/src/testing/oracle_repro.rs
+++ b/factory/src/testing/oracle_repro.rs
@@ -38,6 +38,7 @@ fn test_repro_token_sort_order_bug() {
         atom_bluechip_anchor_pool_address: atom_pool.clone(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO

--- a/factory/src/testing/tests.rs
+++ b/factory/src/testing/tests.rs
@@ -68,6 +68,7 @@ fn create_default_instantiate_msg() -> FactoryInstantiate {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     }
 }
@@ -147,6 +148,7 @@ fn proper_initialization() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -307,6 +309,7 @@ fn create_pair() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -374,6 +377,7 @@ fn test_create_pair_with_custom_params() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -572,6 +576,7 @@ fn test_complete_pool_creation_flow() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -706,6 +711,7 @@ fn test_config() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -747,6 +753,7 @@ fn test_reply_handling() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -1585,6 +1592,7 @@ fn test_query_pyth_atom_usd_price_success() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1630,6 +1638,7 @@ fn test_query_pyth_atom_usd_price_default() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1665,6 +1674,7 @@ fn test_query_pyth_extreme_atom_prices() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1719,6 +1729,7 @@ fn test_get_bluechip_usd_price_with_pyth() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1789,6 +1800,7 @@ fn test_bluechip_usd_price_with_different_atom_prices() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1862,6 +1874,7 @@ fn test_conversion_functions_with_pyth() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
     FACTORYINSTANTIATEINFO
@@ -1945,6 +1958,7 @@ fn test_bluechip_minting_on_threshold_crossing() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -2040,6 +2054,7 @@ fn test_no_mint_when_amount_is_zero() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 

--- a/factory/src/testing/update_tests.rs
+++ b/factory/src/testing/update_tests.rs
@@ -64,6 +64,7 @@ fn test_propose_and_execute_update_config() {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     };
 
@@ -630,6 +631,7 @@ fn default_factory_instantiate_msg() -> FactoryInstantiate {
         atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
         bluechip_mint_contract_address: None,
         bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
         standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
     }
 }

--- a/upload_wasms_and_contracts_plus_starter_pool.sh
+++ b/upload_wasms_and_contracts_plus_starter_pool.sh
@@ -159,6 +159,7 @@ FACTORY_INIT=$(cat <<EOF
   "atom_bluechip_anchor_pool_address": "$ALICE_ADDR",
   "bluechip_mint_contract_address": "$ECON_ADDR",
   "bluechip_denom": "ubluechip",
+  "atom_denom": "uatom",
   "standard_pool_creation_fee_usd": "1000000"
 }
 EOF


### PR DESCRIPTION
Tightens execute_set_anchor_pool from "any standard pool with bluechip on one side" to "exactly the (bluechip, atom) Native/Native pair" so a compromised admin key can't point the oracle anchor at a bluechip/<X> standard pool whose price has no relation to the configured Pyth ATOM/USD feed.

Wire-format change: new `FactoryInstantiate.atom_denom: String` field (set to "uatom" on Cosmos Hub, or the chain's IBC-wrapped atom denom hash on other chains). Validated non-empty + distinct from bluechip_denom by `validate_factory_config`, so it's enforced at instantiate AND at every 48h-timelocked ProposeConfigUpdate.

The field carries `#[serde(default)]` so already-deployed factory records (instantiated pre-this-field) continue to deserialize — they round-trip with an empty atom_denom, and execute_set_anchor_pool explicitly rejects with a "propose ProposeConfigUpdate" pointer until the operator backfills it. New deployments get the strict-non-empty check at instantiate.

Anchor enforcement: filter pool_token_info into Native denoms; require exactly two Natives that match (bluechip_denom, atom_denom) in either order. Anything else (Native/CW20, bluechip + arbitrary Native, etc.) is rejected.

Deploy scripts updated to set atom_denom: "uatom" alongside bluechip_denom. If you're deploying against a non-Hub chain, swap "uatom" for the chain's IBC-wrapped atom denom hash before running.

Tests: full workspace green (~360 tests across all crates).

https://claude.ai/code/session_01RK7kbCgTBJpcofEBCEdL4V