### PR TITLE
docs: rewrite top-level README to match the post-audit architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,38 +33,76 @@ Bluechip is a DeFi protocol that enables content creators to launch their own to
 
 ## Architecture
 
-The protocol consists of three main contracts:
+The protocol is organized as four contracts and two shared library packages:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                      FACTORY CONTRACT                        │
-│  - Creates new creator pools                                 │
-│  - Manages global configuration                              │
-│  - Handles CW20 and CW721 contract instantiation            │
-│  - Internal oracle for bluechip/USD pricing                  │
-│  - Triggers expand economy on pool creation                  │
+│  - Creates creator pools (permissioned) and standard pools   │
+│    (permissionless, paid in USD-denominated bluechip)        │
+│  - Manages global configuration via 48h timelock             │
+│  - Handles CW20 / CW721 / pool wasm instantiation            │
+│  - Internal oracle for bluechip/USD pricing (TWAP + warm-up) │
+│  - Notifies expand-economy on threshold-crossings            │
+│  - Anchor-pool one-shot bootstrap + force-rotate             │
+│  - Keeper bounties (oracle update, distribution batches)     │
 └─────────────────────────────────────────────────────────────┘
-                    │                       │
-                    │ creates               │ requests expansion
-                    ▼                       ▼
-┌──────────────────────────────┐  ┌──────────────────────────────┐
-│        POOL CONTRACT         │  │    EXPAND ECONOMY CONTRACT   │
-│  - Handles commits           │  │  - Mints bluechip tokens on  │
-│  - Manages threshold         │  │    pool creation             │
-│  - Executes swaps & LP ops   │  │  - Decreasing supply curve   │
-│  - Mints NFT LP positions    │  │  - Factory-gated access      │
-│  - Distributes fees          │  │  - Owner admin functions     │
-│  - Creator excess liquidity  │  │                              │
-└──────────────────────────────┘  └──────────────────────────────┘
+        │                  │                  │
+        │ creates           │ creates          │ requests expansion
+        ▼                  ▼                  ▼
+┌────────────────────┐  ┌────────────────────┐  ┌────────────────────┐
+│   CREATOR POOL     │  │   STANDARD POOL    │  │  EXPAND ECONOMY    │
+│  - Commit phase    │  │  - Plain xyk AMM   │  │  - Mints bluechip  │
+│  - Threshold cross │  │    around any two  │  │    on threshold    │
+│  - Post-threshold  │  │    pre-existing    │  │    crossings       │
+│    AMM             │  │    assets          │  │  - 24h rolling cap │
+│  - Distribution    │  │  - SubMsg-based    │  │  - 48h timelocks   │
+│    batches +       │  │    deposit balance │  │    on config /     │
+│    keeper bounty   │  │    verification    │  │    withdrawal      │
+│  - Threshold-cross │  │    (FoT / rebase   │  │  - Owner / factory │
+│    NFT auto-accept │  │    safe)           │  │    role separation │
+│                    │  │  - Factory-driven  │  │  - Cosmos-SDK      │
+│                    │  │    NFT auto-accept │  │    denom format    │
+│                    │  │                    │  │    validation      │
+└────────────────────┘  └────────────────────┘  └────────────────────┘
+        │                          │
+        │ depend on                │
+        ▼                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│              POOL-CORE  (shared library package)             │
+│  - Constant-product AMM math + slippage / spread guards      │
+│  - Position-NFT helpers (deposit, add, remove, collect fees) │
+│  - First-depositor MINIMUM_LIQUIDITY inflation lock          │
+│  - Reentrancy lock shared across every hot path              │
+│  - Auto-pause when reserves drop below MINIMUM_LIQUIDITY     │
+│  - Two-phase emergency withdraw (24h timelock)               │
+│  - Strict per-asset fund collection (no orphaned coins)      │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│       POOL-FACTORY-INTERFACES  (shared types package)        │
+│  - Wire-format types both pools and the factory speak        │
+│  - CW721 message shapes, asset / token-info types,           │
+│    factory-bound message envelopes                           │
+└─────────────────────────────────────────────────────────────┘
 ```
+
+### Pool Kinds
+
+| Kind | Created By | Has Commit Phase | Mints CW20 | Cross-Threshold Mint |
+|------|-----------|------------------|------------|---------------------|
+| **Creator Pool** | Factory admin (rate-limited 1h/address) | Yes — funds via subscriptions until USD threshold | Yes (1.5M cap, factory-minted) | Yes (notifies expand-economy) |
+| **Standard Pool** | Anyone (pays USD-denominated fee) | No — tradeable / depositable from instantiate | No (wraps two pre-existing assets) | No (does NOT participate in mint formula) |
+
+Both pool kinds share the same liquidity/swap/position logic via `pool-core`, the same emergency-withdraw machinery, and the same factory message envelope. The differences live in the entry-point crates and the commit-phase code that creator-pool exclusively owns.
 
 ---
 
 ## How It Works
 
-### Creating a Pool
+### Creating a Creator Pool
 
-Creators can launch their own token pool by calling the factory contract. Calling the contract can be done via the BlueChip website or by using the below JSON.
+Creators can launch their own token pool by calling the factory contract. This is the original commit-phase flow.
 
 ```json
 {
@@ -94,15 +132,42 @@ Creators can launch their own token pool by calling the factory contract. Callin
 }
 ```
 
-Each pool receives:
+Each creator pool receives:
 - A unique CW20 token for the creator (mint cap: 1,500,000)
 - A CW721 NFT contract for liquidity positions
 - Configurable fee structure (default: 1% protocol + 5% creator)
-- bluechip tokens minted via the Expand Economy contract (up to 500M per creation, decreasing over time)
+- Bluechip tokens minted via the Expand Economy contract on threshold-crossing (up to 500 per pool, decreasing over time)
+
+A per-address rate limit (1 hour) on `Create` calls keeps an attacker from cheaply inflating the commit-pool ordinal that drives the expand-economy decay schedule.
+
+### Creating a Standard Pool
+
+Anyone can create a plain xyk pool around two pre-existing assets via `CreateStandardPool`. The caller pays a USD-denominated fee in bluechip; the factory converts USD to bluechip via the internal oracle at call time, with a hardcoded fallback for the very first pool (the ATOM/bluechip anchor pool itself).
+
+```json
+{
+  "create_standard_pool": {
+    "asset_infos": [
+      { "native_token": { "denom": "ubluechip" } },
+      { "token": { "contract_addr": "cosmos1..." } }
+    ],
+    "label": "ubluechip-MYTOKEN-xyk"
+  }
+}
+```
+
+Standard pools:
+- Are immediately tradeable / depositable at creation (no threshold)
+- Do NOT mint a fresh CW20 — they wrap pre-existing assets
+- Do NOT participate in the expand-economy mint formula (defense-in-depth guard inside `calculate_and_mint_bluechip` rejects them)
+- Use `pool-core`'s SubMsg-based deposit balance verification path so fee-on-transfer or rebasing CW20s cannot corrupt reserve accounting (mismatch reverts the entire transaction)
+- Receive an explicit factory callback that accepts NFT ownership in the same transaction as creation, closing the pending-ownership window before any user can interact
 
 ---
 
-## Two-Phase Pool Lifecycle
+## Two-Phase Pool Lifecycle (Creator Pool)
+
+This section covers the **creator-pool** flow only. Standard pools skip the commit phase entirely and start in active-trading mode.
 
 ### Phase 1: Pre-Threshold (Funding Phase)
 
@@ -128,8 +193,10 @@ When total USD committed reaches the threshold ($25,000 default):
 3. **Protocol reward**: 25,000 creator tokens sent to the Bluechip protocol wallet
 4. **Pool seeded**: 350,000 creator tokens + committed bluechip used to initialize AMM liquidity
 5. **Committer distribution**: 500,000 creator tokens distributed to committers proportionally
-6. **Excess handling**: If bluechip exceeds `max_bluechip_lock_per_pool`, excess bluechip and proportional creator tokens are sent directly to the creator's wallet (see [Creator Limits](#creator-limits--excess-liquidity))
-7. **State transition**: Pool moves to active trading phase
+6. **Excess handling**: If bluechip exceeds `max_bluechip_lock_per_pool`, excess bluechip and proportional creator tokens are held in time-locked escrow for the creator (see [Creator Limits](#creator-limits--excess-liquidity))
+7. **NFT auto-accept**: The pool sends `Cw721 AcceptOwnership` for its position-NFT contract in the same transaction as the threshold crossing — no pending-ownership window
+8. **Expand-economy notification**: The factory's `NotifyThresholdCrossed` reply chain dispatches a bluechip mint via the expand-economy contract (subject to the 24h rolling cap)
+9. **State transition**: Pool moves to active trading phase
 
 ```
 Token Distribution Formula:
@@ -147,11 +214,13 @@ Once the threshold is crossed, the pool operates as a full AMM:
 - **Remove Liquidity**: Withdraw liquidity (partial or full)
 - **Collect Fees**: Claim accumulated trading fees without burning position
 
+A 2-block post-threshold cooldown delays the first swap to prevent bundling a manipulative swap into the same block as the threshold-crossing tx.
+
 ---
 
 ## The Commit Function (Subscribe Button)
 
-The commit function is the core user interaction for subscriptions:
+The commit function is the core user interaction for subscriptions.
 
 ```json
 {
@@ -167,15 +236,15 @@ The commit function is the core user interaction for subscriptions:
 }
 ```
 
-**Send with:** Native bluechip tokens attached to the transaction, in the same `amount` as `asset.amount`. Commit transactions can only be carried out with bluechip tokens.
+**Send with:** Native bluechip tokens attached to the transaction, in the same `amount` as `asset.amount`. Commit transactions can only be carried out with bluechip tokens. The handler uses `cw_utils::must_pay` for strict denom-and-amount validation, so attaching the wrong denom or a different amount fails fast.
 
 ### What Happens When You Commit
 
 **Pre-Threshold:**
-1. USD value calculated using oracle price
+1. USD value calculated using the oracle rate captured once at handler entry (no mid-tx drift)
 2. 6% fee deducted and distributed (1% protocol, 5% creator)
 3. Commitment recorded in ledger
-4. If threshold crossed, triggers token distribution
+4. If threshold crossed, triggers atomic token distribution
 
 **Post-Threshold:**
 1. 6% fee deducted and distributed
@@ -199,7 +268,7 @@ The commit function is the core user interaction for subscriptions:
 
 ## NFT Liquidity Positions
 
-Unlike traditional AMMs that issue fungible LP tokens, Bluechip uses NFTs to represent liquidity positions.
+Both creator pools and standard pools represent liquidity positions as NFTs (logic shared via `pool-core`).
 
 ### Benefits of NFT Positions
 
@@ -207,6 +276,10 @@ Unlike traditional AMMs that issue fungible LP tokens, Bluechip uses NFTs to rep
 - **Transferable Positions**: Sell or transfer your liquidity position as an NFT
 - **Position Tracking**: Each position tracks its own fee accumulation history
 - **Partial Withdrawals**: Remove part of your liquidity while keeping the NFT
+
+### First-Depositor Inflation Lock
+
+The first depositor on an empty pool has `MINIMUM_LIQUIDITY = 1000` LP units locked into their position. The locked units cannot be withdrawn (the position itself can still earn and collect fees), neutralising the classic "donate-then-deposit" share-price-inflation attack on a freshly seeded pool.
 
 ### Adding Liquidity
 
@@ -220,7 +293,9 @@ Unlike traditional AMMs that issue fungible LP tokens, Bluechip uses NFTs to rep
 }
 ```
 
-**Returns:** NFT representing your liquidity position
+**Returns:** NFT representing your liquidity position.
+
+On a **standard pool** the deposit is dispatched as a SubMsg with `reply_on_success`. The pool's reply handler re-queries the CW20 balance and asserts that `post − pre == credited`. Any mismatch (fee-on-transfer / rebase) reverts the entire transaction so reserve accounting cannot drift away from the pool's actual on-chain balance.
 
 ### Adding to Existing Position
 
@@ -252,6 +327,8 @@ Fees are calculated using a global fee growth accumulator:
 fees_owed = (fee_growth_global - fee_growth_at_last_collection) × position_liquidity
 ```
 
+Small positions are subject to a fee-size multiplier; the clipped portion is routed to a creator-fee pot rather than being lost, so dust positions can't farm fees disproportionately.
+
 ### Removing Liquidity
 
 ```json
@@ -263,7 +340,7 @@ fees_owed = (fee_growth_global - fee_growth_at_last_collection) × position_liqu
 }
 ```
 
-Partial removal keeps the NFT; full removal burns it.
+Partial removal keeps the NFT; full removal burns it. Pulling reserves below `MINIMUM_LIQUIDITY` auto-pauses the pool (separate auto-pause flag); the pause clears automatically as soon as a deposit restores reserves above the floor.
 
 ---
 
@@ -290,6 +367,8 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 │               INTERNAL ORACLE (FACTORY)                      │
 │  - Weighted average from multiple pools                      │
 │  - TWAP for manipulation resistance                          │
+│  - Warm-up gate after anchor change / force-rotate           │
+│  - Per-update circuit breaker (30% drift cap)                │
 │  - Random pool rotation for security                         │
 └─────────────────────────────────────────────────────────────┘
 ```
@@ -303,9 +382,20 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 ### Manipulation Resistance
 
 - **TWAP (Time-Weighted Average Price)**: Smooths out temporary price spikes
-- **Pool Rotation**: Randomly selects pools to prevent targeted manipulation
+- **Pool Rotation**: Randomly selects pools (every `ROTATION_INTERVAL = 3600s`) to prevent targeted manipulation
 - **Liquidity Weighting**: Higher liquidity pools have more influence
-- **Outlier Detection**: Rejects prices that deviate significantly from TWAP
+- **TWAP Circuit Breaker**: Each update is rejected if it deviates by more than `MAX_TWAP_DRIFT_BPS = 30%` from the prior published price (the very first update bypasses the breaker by definition)
+- **Warm-Up Gate**: After bootstrap, an admin-driven anchor change, or `ForceRotateOraclePools`, the oracle requires `ANCHOR_CHANGE_WARMUP_OBSERVATIONS = 6` successive successful TWAP rounds before downstream USD conversions resume — preventing the very first post-reset observation from being locked in by an attacker who briefly perturbed the new anchor's reserves
+- **Stale-Price Rejection**: Pyth prices older than `MAX_PRICE_AGE_SECONDS_BEFORE_STALE = 90s` are rejected
+- **Cached Eligible-Pool Snapshot**: O(N) scan of `POOLS_BY_ID` is amortised across `ELIGIBLE_POOL_REFRESH_BLOCKS = 72,000` (~5 days at 6s blocks); per-update gas is O(sample_size) regardless of total pool count
+
+### Force-Rotate (Admin)
+
+`ForceRotateOraclePools` is a 2-step admin action gated by the standard 48-hour `PENDING_ORACLE_ROTATION` timelock. On execution, the oracle clears its cumulative snapshots, clears the price cache, re-arms the warm-up gate, and re-selects its sample set — preventing a compromised admin from instantly rotating the oracle's sample set without a community-observable window.
+
+### Keeper Bounty
+
+`UpdateOraclePrice` is permissionless and pays a USD-denominated bounty (capped at $0.10) to the caller, paid out in bluechip after USD→bluechip conversion. The existing per-update interval gates frequency, so the bounty cannot be spammed.
 
 ---
 
@@ -329,6 +419,8 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 }
 ```
 
+Standard pools return `is_threshold_hit: true` from instantiate (no commit phase).
+
 ### Commit Status
 
 ```json
@@ -346,6 +438,8 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 }
 ```
 
+(Creator-pool only — standard pools surface `FullyCommitted` with zeros.)
+
 ### Position Info
 
 ```json
@@ -353,17 +447,6 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
   "get_position": {
     "position_id": "123"
   }
-}
-```
-
-**Returns:**
-```json
-{
-  "position_id": "123",
-  "owner": "bluechip1...",
-  "liquidity": "1000000",
-  "fee_growth_inside_0_last": "0.001",
-  "fee_growth_inside_1_last": "0.002"
 }
 ```
 
@@ -388,32 +471,13 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 }
 ```
 
-**Returns:**
-```json
-{
-  "analytics": { "total_swaps": 42, "total_commits": 10, "..." : "..." },
-  "current_price_0_to_1": "5.0",
-  "current_price_1_to_0": "0.2",
-  "total_value_locked_0": "1000000000",
-  "total_value_locked_1": "5000000000",
-  "fee_reserve_0": "50000",
-  "fee_reserve_1": "250000",
-  "threshold_status": { "total_usd_raised": "25000000000", "threshold": "25000000000", "is_active": true },
-  "total_usd_raised": "25000000000",
-  "total_bluechip_raised": "100000000",
-  "total_positions": 15
-}
-```
-
-Provides a comprehensive snapshot of pool state for indexers and analytics dashboards, including pricing, TVL, fee reserves, and threshold status.
+Provides a comprehensive snapshot of pool state for indexers and analytics dashboards (TVL, fee reserves, threshold status, position count, swap/commit counters, current spot prices in both directions).
 
 ---
 
 ## Integration Guide
 
 ### Embedding the Commit Button
-
-The commit function can be called from any frontend that supports Cosmos transactions:
 
 ```javascript
 // Using CosmJS
@@ -440,9 +504,36 @@ const result = await client.execute(
 );
 ```
 
-### Checking Subscription Status
+### Standard-Pool Deposit (CW20 Approval Required)
 
-Query the commit ledger to verify subscription status:
+```javascript
+// Approve the standard pool to spend the CW20 first.
+await client.execute(senderAddress, cw20Address, {
+  increase_allowance: { spender: standardPoolAddress, amount: "1000000" }
+}, "auto");
+
+// Deposit native + CW20.
+await client.execute(
+  senderAddress,
+  standardPoolAddress,
+  {
+    deposit_liquidity: {
+      amount0: "1000000",
+      amount1: "1000000",
+      min_amount0: null,
+      min_amount1: null,
+      transaction_deadline: null
+    }
+  },
+  "auto",
+  undefined,
+  [{ denom: "ubluechip", amount: "1000000" }]
+);
+```
+
+The standard-pool reply handler will reject the transaction if the CW20 has a transfer fee or rebase that makes the credited delta differ from `amount1`.
+
+### Checking Subscription Status
 
 ```json
 {
@@ -457,38 +548,59 @@ Query the commit ledger to verify subscription status:
 ## Security Considerations
 
 ### Reentrancy Protection
-- Guard implemented on commit transactions
-- State updates occur before external calls
+- Single shared `REENTRANCY_LOCK` covering commit, swap, and every liquidity path on both pool kinds, so a hostile CW20's transfer hook can't reach any handler from any other path mid-execution.
+- State updates occur before external calls.
 
 ### Oracle Security
-- TWAP (3600-second window) prevents flash loan price manipulation
-- Multiple pool sampling (5 pools: 4 random + ATOM anchor) reduces single-point-of-failure risk
-- Price update rate-limited to every 300 seconds
-- Stale price detection (3000-second max age)
-- Pool rotation every 3600 seconds to prevent targeted manipulation
+- TWAP smoothing across multiple sampled pools.
+- Warm-up gate (6 successive observations) re-arms after every bootstrap, anchor change, and admin-triggered force-rotate, preventing first-observation-after-reset from being locked in.
+- Per-update TWAP circuit breaker (30% max drift) rejects out-of-band price moves on every update after the first.
+- Random pool rotation every 3600 seconds.
+- Stale-price rejection at 90 seconds (Pyth).
+- Oracle update interval rate-limit (300 seconds) bounds bounty drain.
+- Keeper bounty USD-denominated and hard-capped at $0.10 — caps yearly drain at ~$10.5k worst-case if admin is compromised.
 
 ### Threshold Mechanics
-- Threshold can only be crossed once (irreversible)
-- Atomic state transitions during threshold crossing
-- USD-based tracking prevents token price manipulation
-- Batched distribution for large committer sets (>40)
-- Stuck state recovery mechanism (factory admin, after 1 hour timeout)
+- Threshold can only be crossed once (irreversible).
+- Atomic state transitions during threshold crossing — the entire payout (creator share, protocol share, committer distribution, AMM seeding, NFT auto-accept, expand-economy notification) lives in a single tx.
+- USD-based tracking prevents token-price manipulation around the threshold.
+- Batched distribution for large committer sets (>40), with per-call keeper bounty paid by the factory.
+- Stuck-state recovery via `RecoverStuckStates` (factory admin, after timeout); handler refuses to operate on already-drained pools.
+- 2-block post-threshold cooldown delays the first swap so an attacker can't bundle a manipulative swap into the threshold-crossing block.
+
+### Per-Address Rate Limit on Pool Creation
+- 1-hour cooldown per `info.sender` on creator-pool creation. Defends against trivial spam-creates that would inflate the commit-pool ordinal and gas-amplify per-pool storage scans. Coordinated multi-address spam still has to fund and sign from each new address it rotates through.
+
+### Standard-Pool / Pool-Core Defenses
+- **SubMsg-based deposit balance verification** (standard-pool only): each CW20-side TransferFrom is anchored by a `reply_on_success` SubMsg whose handler re-queries the post-balance and asserts equality with the credited delta. Strict equality (not `≥`) so both fee-on-transfer shortfalls and inflate-on-transfer overages revert.
+- **Strict per-asset fund collection**: deposits reject any attached coin whose denom isn't one of the pool's configured native sides. Pre-fix, accidentally attached IBC / tokenfactory denoms would have orphaned in the pool's bank balance.
+- **First-depositor MINIMUM_LIQUIDITY lock**: 1000 LP units locked on the first deposit's position; cannot be withdrawn. Fees still accrue against the locked amount.
+- **Auto-pause on low reserves**: a remove-liquidity that drops reserves below `MINIMUM_LIQUIDITY` flips a separate `POOL_PAUSED_AUTO` flag (distinct from admin pauses). Deposits are permitted while auto-paused so the recovery path stays open; swaps and removes are not. Auto-flag clears as soon as a deposit restores reserves above the floor.
+- **NFT pending-ownership window closed**: standard-pool's `AcceptNftOwnership` factory callback runs in the same tx as pool creation; creator-pool auto-accepts at threshold-cross. No window where the NFT contract has the pool as `pending_owner` but not actual owner.
+- **Migrate downgrade guard**: every contract's migrate handler parses cw2-stored version and compile-time `CONTRACT_VERSION` as semver and refuses any migrate where stored > current.
+
+### Two-Phase Emergency Withdraw
+- Phase 1 (`EmergencyWithdraw` while no pending) sets the timelock and pauses the pool.
+- Phase 2 (`EmergencyWithdraw` while pending and >24h elapsed) drains reserves to the configured bluechip wallet.
+- `CancelEmergencyWithdraw` is available to the factory admin during Phase 1.
+- Standard pools route the drain to the configured `bluechip_wallet_address` (NOT the factory contract — funds sent there would be permanently locked since the factory has no withdrawal mechanism).
 
 ### Swap Validation
-- Zero-amount CW20 swaps are rejected
-- Creator tokens are enforced to use 6 decimals to match hardcoded payout amounts
+- Zero-amount CW20 swaps are rejected.
+- Creator tokens are enforced to use 6 decimals to match hardcoded payout amounts.
+- `usd_payment_tolerance_bps` was removed during audit (the field was unused dead code; the relevant invariants are enforced elsewhere).
 
 ### Commit Rate Limiting
-- Minimum 13 seconds between commits per wallet
-- USD payment tolerance of 1% (100 bps) for oracle price drift, capped at a maximum of 10% (1000 bps)
+- Minimum 13 seconds between commits per wallet.
+- Oracle rate is captured once at commit entry and threaded through every conversion in the handler — no mid-tx drift between the USD valuation and the threshold check.
 
 ### Threshold Crossing Protection
-- Excess swap at threshold crossing is capped at 20% of pool reserves, preventing a single large committer from dominating the first trade on a freshly seeded pool
-- Any excess beyond the cap is refunded to the committer
+- Excess swap at threshold crossing is capped at 20% of pool reserves, preventing a single large committer from dominating the first trade.
+- Any excess beyond the cap is refunded to the committer.
 
 ### Payout Integrity Validation
-- All threshold payout components validated (no zero amounts)
-- No individual component can exceed total
+- All threshold payout components validated (no zero amounts).
+- No individual component can exceed the total.
 
 ---
 
@@ -505,7 +617,7 @@ Each creator pool mints a total of **1,200,000** creator tokens at threshold cro
 | Protocol (Bluechip Wallet) | 25,000 | ~2.1% | Protocol sustainability |
 | Pool Liquidity Seed | 350,000 | ~29.2% | Initial AMM liquidity |
 
-The CW20 token contract is instantiated with a mint cap of **1,500,000,**, allowing for future controlled minting beyond the initial threshold distribution.
+The CW20 token contract is instantiated with a mint cap of **1,500,000**, allowing for future controlled minting beyond the initial threshold distribution.
 
 ### Fee Flow
 
@@ -521,25 +633,28 @@ Commit Transaction (5000 bluechip)
 
 ## Expand Economy
 
-The Expand Economy contract manages bluechip token inflation by minting new tokens each time a creator pool is created. This incentivizes early adoption while gradually reducing emissions as the ecosystem grows.
+The Expand Economy contract manages bluechip token inflation by minting new tokens each time a creator pool crosses its threshold. This incentivizes early adoption while gradually reducing emissions as the ecosystem grows.
 
 ### How It Works
 
 ```
-┌──────────────┐         ┌───────────────────┐         ┌──────────────────┐
-│   Creator    │ ──────► │  Factory Contract  │ ──────► │  Expand Economy  │
-│ creates pool │         │  calculate_mint()  │         │  RequestExpansion│
-└──────────────┘         └───────────────────┘         └──────────────────┘
-                                                               │
-                                                               ▼
-                                                    Mints bluechip tokens
-                                                    to protocol wallet
+┌──────────────┐     ┌────────────────────┐     ┌───────────────────┐
+│   Creator    │ ──► │  Factory Contract   │ ──► │  Expand Economy   │
+│ pool crosses │     │ NotifyThresholdCross│     │  RequestExpansion │
+│  threshold   │     │ calculate_mint()    │     │  (24h cap, factory│
+└──────────────┘     └────────────────────┘     │   role gated)     │
+                                                 └───────────────────┘
+                                                          │
+                                                          ▼
+                                              Mints bluechip tokens
+                                              to protocol wallet
 ```
 
-1. A creator calls the factory to create a new pool
-2. The factory calculates a mint amount based on time elapsed and total pools created
-3. The factory sends a `RequestExpansion` message to the Expand Economy contract
-4. The Expand Economy contract sends the calculated amount of bluechip (`stake`) tokens to the protocol wallet
+1. A commit pushes a creator pool past its USD threshold.
+2. The pool fires `NotifyThresholdCrossed` to the factory (subject to one-shot `POOL_THRESHOLD_MINTED` — never twice for the same pool).
+3. The factory rejects standard pools, then computes the mint amount via the decay formula.
+4. The factory sends `RequestExpansion` to the Expand Economy contract.
+5. Expand-economy validates the request (factory-only, denom cross-check against the factory's configured `bluechip_denom`, daily cap, sufficient balance) and dispatches a `BankMsg::Send` to the protocol wallet.
 
 ### Mint Formula
 
@@ -548,35 +663,48 @@ mint_amount = 500 - ((5x² + x) / ((s / 6) + 333x))
 ```
 
 Where:
-- **x** = total pools created
-- **s** = seconds elapsed since the first pool was created
+- **x** = `commit_pool_ordinal` — a commit-pool-only counter (NOT the global `pool_id`). Standard-pool creations cannot inflate `x`.
+- **s** = seconds elapsed since the first threshold-crossing
 - **Result** is in whole tokens (multiplied by 10⁶ for micro-denomination)
 
 **Properties:**
-- **Maximum mint**: 500 `stake` tokens per pool creation
-- **Decreasing curve**: Mint amount decreases as more pools are created
-- **Time decay**: Longer time between pool creations further reduces the mint
+- **Maximum mint**: 500 bluechip per threshold-crossing
+- **Decreasing curve**: Mint amount decreases as more commit pools cross threshold
+- **Time decay**: Longer time between threshold-crossings further reduces the mint
 - **Floor**: Mint amount cannot go below zero
+
+### Daily Expansion Cap
+
+`DAILY_EXPANSION_CAP = 100,000,000,000 ubluechip` (= 100,000 bluechip) bounds the worst-case daily drain if the configured factory address is ever compromised. The window is a single bucket that resets opportunistically on the first call after `DAILY_WINDOW_SECONDS = 86,400` has elapsed since the bucket's start. Skipped requests (insufficient balance, dormant decay) do not burn cap budget.
+
+### Cross-Validation
+
+Every `RequestExpansion` cross-validates the factory's configured `bluechip_denom` against this contract's stored denom. A mismatch (admin updated one side without the other) returns an explicit error rather than silently funding rewards in the wrong denom.
 
 ### Access Control
 
 | Action | Who Can Call |
 |--------|-------------|
-| `RequestExpansion` | Factory contract only |
-| `UpdateConfig` | Owner only |
-| `Withdraw` | Owner only |
+| `RequestExpansion` | Factory contract only (sender check + denom cross-validation) |
+| `ProposeConfigUpdate` / `ExecuteConfigUpdate` / `CancelConfigUpdate` | Owner (48h timelock) |
+| `ProposeWithdrawal` / `ExecuteWithdrawal` / `CancelWithdrawal` | Owner (48h timelock) |
+| `migrate` | Chain admin (downgrade rejected) |
+
+Every execute path is non-payable — `cw_utils::nonpayable` rejects any attached funds at dispatch, so coins attached to a propose/cancel/request call cannot orphan in the contract's bank balance.
+
+The owner-supplied `bluechip_denom` (instantiate or config update) is validated against the cosmos-sdk denom format (`^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$`) at submission time, surfacing typos at propose rather than 48h later when the bank module would have rejected.
 
 ### Query Endpoints
 
 ```json
 { "get_config": {} }
 ```
-Returns the factory address and owner.
+Returns `{ factory_address, owner, bluechip_denom }`.
 
 ```json
-{ "get_balance": { "denom": "stake" } }
+{ "get_balance": { "denom": "ubluechip" } }
 ```
-Returns the contract's balance of the specified denomination.
+Returns the contract's bank balance of the specified denomination.
 
 ---
 
@@ -584,18 +712,18 @@ Returns the contract's balance of the specified denomination.
 
 ### Maximum Bluechip Lock Per Pool
 
-Each pool enforces a maximum amount of bluechip tokens that can be locked as liquidity upon the threshold being crossed. This is to preotect the ecosystem from having all the bluechips getting locked in unowned liquidity positions (`max_bluechip_lock_per_pool`). When the bluechip tokens committed to a pool exceed this limit at threshold crossing, the excess is not lost, it is held in a time-locked escrow for the creator. The maximum amount of bluechips is therefore, also used as an incentive for creators to join the network while bluechips are lower in value. 
+Each pool enforces a maximum amount of bluechip tokens that can be locked as liquidity at threshold crossing (`max_bluechip_lock_per_pool`). This prevents the ecosystem from having all bluechip locked into unowned liquidity positions and incentivises creators to join while bluechip is lower in value. When committed bluechip exceeds this limit at threshold crossing, the excess is held in a time-locked escrow for the creator rather than being lost.
 
 ### Creator Excess Liquidity
 
-When bluechips exceed the per-pool maximum:
+When bluechip exceeds the per-pool maximum:
 
 1. The excess bluechip and proportional creator tokens are stored in a `CreatorExcessLiquidity` record
 2. An unlock timestamp is set based on `creator_excess_liquidity_lock_days` (configured at the factory level)
 3. After the lock period expires, the creator can claim the excess tokens directly to their wallet
 
 ```
-Threshold Crossing (e.g., 15M bluechip committed, 10M max per pool)
+Threshold Crossing (e.g., 15B bluechip committed, 10B max per pool)
         │
         ├── 10B bluechip → Pool liquidity (immediate)
         └── 5B bluechip + proportional creator tokens → Time-locked
@@ -655,9 +783,13 @@ Each committer receives tokens proportional to their USD contribution:
 user_tokens = (user_usd_contribution / total_usd_committed) × commit_return_amount
 ```
 
+### Keeper Bounty
+
+`ContinueDistribution` is permissionless and pays a USD-denominated bounty (capped at $0.10) to the caller for each successful batch, paid out in bluechip from the factory's pre-funded native balance. A 5-second per-address cooldown on `ContinueDistribution` prevents a single keeper from monopolising the bounty.
+
 ### Recovery
 
-If distribution gets stuck (>1 hour or 5+ consecutive failures), the factory admin can trigger `RecoverStuckStates` to resume processing.
+If distribution gets stuck (>1 hour or 5+ consecutive failures), the factory admin can trigger `RecoverStuckStates` to resume processing. The handler refuses to operate on already-drained pools (defense-in-depth against state corruption between drain and recovery attempts).
 
 ---
 
@@ -665,11 +797,11 @@ If distribution gets stuck (>1 hour or 5+ consecutive failures), the factory adm
 
 ### Factory Configuration Updates
 
-Configuration updates use a timelock mechanism:
+Configuration updates use a 48-hour timelock:
 
-1. Admin calls `ProposeConfigUpdate` with new values
-2. A 48-hour timelock is applied
-3. After the timelock expires, `UpdateConfig` applies the pending changes
+1. Admin calls `ProposeConfigUpdate` with new values (factory-side validation rejects empty strings, invalid bech32, non-positive fees, fee-sum overflow, malformed Pyth address / feed id)
+2. The proposal does NOT overwrite an existing pending update — `Cancel` first if you need to replace
+3. After the 48h timelock expires, `UpdateConfig` applies the pending changes
 
 ### Pool Configuration Updates
 
@@ -693,13 +825,32 @@ Pools can be migrated to new contract code in batches:
 }
 ```
 
+- 48h timelock before execution
+- Anchor pool is excluded from upgrade lists (reject at propose time)
+- `pool_ids` is deduplicated before applying
 - Processes up to 10 pools per transaction
 - Automatically continues with `ContinuePoolUpgrade` until all pools are migrated
-- Can target specific pools or upgrade all pools
+- Skips paused pools rather than reverting the entire batch
+
+### Force-Rotate Oracle Pools
+
+`ProposeOracleRotation` → wait 48h → `ForceRotateOraclePools`. On execution, the oracle clears cumulative snapshots, clears the price cache, re-arms the warm-up gate, and re-selects its sample set.
+
+### Anchor Pool Bootstrap
+
+`SetAnchorPool { pool_id }` is a one-shot bootstrap callable until `INITIAL_ANCHOR_SET = true`. The handler enforces that the anchor pool's non-bluechip side matches the factory's configured `atom_denom` exactly. After the one-shot fires, any subsequent change must go through the standard 48h `ProposeConfigUpdate` flow.
 
 ### Pool Pause/Unpause
 
-The factory admin can pause individual pools, disabling all swap and liquidity operations while preserving state.
+The factory admin can pause individual pools, disabling all swap and liquidity operations while preserving state. Admin pauses are tracked separately from the auto-pause flag — admin-paused pools require explicit `Unpause`, while auto-paused pools clear themselves when reserves recover.
+
+### Migration
+
+Every contract (factory, creator-pool, standard-pool, expand-economy) exports a migrate entry point that:
+- Tolerates a missing cw2 entry (legacy / test fixtures)
+- Parses both the stored cw2 version and the compile-time `CONTRACT_VERSION` as semver
+- **Refuses any migrate where stored > current** (downgrade protection)
+- Bumps the cw2 record on success
 
 ---
 
@@ -707,26 +858,39 @@ The factory admin can pause individual pools, disabling all swap and liquidity o
 
 | Parameter | Value | Description |
 |-----------|-------|-------------|
-| Commit threshold (USD) | 25,000 | USD value required to activate pool |
-| Commit threshold (bluechip) | 100,000,000 | bluechip token threshold |
-| Creator token mint cap | 1,500,000 | Max CW20 supply per pool |
+| Commit threshold (USD) | 25,000 | USD value required to activate creator pool |
+| Creator token mint cap | 1,500,000 | Max CW20 supply per creator pool |
 | Max bluechip lock per pool | 10,000,000,000 | Excess is time-locked for creator |
 | Creator excess lock period | 7 days | Time before creator can claim excess |
 | Commit fee (protocol) | 1% | Sent to Bluechip wallet |
 | Commit fee (creator) | 5% | Sent to creator wallet |
 | LP swap fee | 0.3% | Distributed to liquidity providers |
-| Max excess swap at threshold | 20% of pool reserves | Prevents single committer from dominating first trade |
-| Max usd_payment_tolerance_bps | 1000 (10%) | Hard cap on oracle price drift tolerance |
+| Max excess swap at threshold | 20% of pool reserves | Caps single-committer dominance of the first trade |
 | Creator token decimals | 6 | Enforced to match hardcoded payout amounts |
-| Min commit interval | 13 seconds | Rate limit per wallet |
-| Expand economy max mint | 500 | Max bluechip minted per pool creation |
-| Oracle TWAP window | 3600 seconds | Time-weighted average price window |
-| Oracle update interval | 300 seconds | Min time between price updates |
-| Oracle price max age | 3000 seconds | Price considered stale after this |
-| Min pool liquidity | 1,000 | Liquidity required to unpause pool |
+| Min commit interval | 13 seconds | Per-wallet commit rate limit |
+| First-depositor lock | 1000 LP | `MINIMUM_LIQUIDITY` locked into first deposit |
 | Distribution batch size | 40 | Max committers per distribution tx |
+| Distribution keeper cooldown | 5 seconds | Per-address, prevents bounty monopoly |
+| Commit-pool create rate limit | 3600 seconds | Per-address, per `Create` call |
 | Default slippage | 0.5% | Default max slippage for swaps |
 | Max slippage | 50% | Hard cap on swap slippage |
+| Post-threshold swap cooldown | 2 blocks | Delays first swap after threshold |
+| Emergency withdraw timelock | 86,400 s (24h) | Phase 1 → Phase 2 delay |
+| Admin timelock (factory) | 172,800 s (48h) | Config / upgrade / force-rotate |
+| Admin timelock (expand-economy) | 172,800 s (48h) | Config update + withdrawal |
+| Oracle TWAP window | 3600 seconds | Time-weighted price window |
+| Oracle update interval | 300 seconds | Min between price updates |
+| Oracle stale-price max age | 90 seconds | Pyth price max age |
+| Oracle rotation interval | 3600 seconds | Random pool re-selection |
+| Oracle warm-up observations | 6 | Required after anchor change / rotate |
+| Oracle TWAP drift cap | 30% (3000 bps) | Per-update circuit breaker |
+| Min eligible pools for TWAP | 3 | Below this the oracle returns InsufficientData |
+| Min pool liquidity (oracle eligibility) | 10,000,000,000 | Per-pool gate for TWAP sampling |
+| Eligible-pool refresh window | 72,000 blocks (~5d) | Snapshot rebuild cadence |
+| Oracle update bounty cap | $0.10 USD (6 dec) | Per successful update |
+| Distribution batch bounty cap | $0.10 USD (6 dec) | Per successful batch |
+| Expand-economy daily cap | 100,000,000,000 ubluechip | Rolling 24h cap on `RequestExpansion` |
+| Expand-economy window | 86,400 seconds | Single-bucket reset interval |
 
 ---
 
@@ -748,18 +912,42 @@ docker run --rm -v "$(pwd)":/code \
 ### Testing
 
 ```bash
-cargo test
+cargo test --workspace --lib
+```
+
+The workspace ships with extensive coverage:
+- factory: 130 tests
+- creator-pool: 165 tests
+- standard-pool: 65 tests
+- expand-economy: 29 tests
+- pool-core: 25 tests
+
+### Repository Layout
+
+```
+bluechip-contracts/
+├── factory/                          # Factory contract
+├── creator-pool/                     # Creator pool (commit + AMM)
+├── standard-pool/                    # Plain xyk pool
+├── expand-economy/                   # Bluechip mint reservoir
+├── packages/
+│   ├── pool-core/                    # Shared AMM library
+│   └── pool-factory-interfaces/      # Shared wire-format types
+├── keepers/                          # Off-chain bots (oracle / distribution)
+└── frontend/                         # Reference UI
 ```
 
 ### Deployment Order
 
-1. Deploy CW20-base contract (store code)
-2. Deploy CW721-base contract (store code)
-3. Deploy Expand Economy contract
-4. Deploy Factory contract with code IDs and Expand Economy address
-5. Create ATOM/bluechip oracle pool first
-6. Initialize internal oracle
-7. Creators can now create pools
+1. Deploy CW20-base and CW721-base wasms (store code)
+2. Deploy `expand-economy` contract
+3. Deploy `factory` contract with the code IDs and the expand-economy address
+4. Set `bluechip_mint_contract_address` on the factory if not already set
+5. Use `CreateStandardPool` to create the ATOM/bluechip anchor pool first
+6. Call `SetAnchorPool { pool_id }` on the factory (one-shot bootstrap, must match `atom_denom`)
+7. Initialize the internal oracle (first `UpdateOraclePrice` call seeds snapshots)
+8. Wait for the oracle warm-up gate to clear (6 successful TWAP rounds)
+9. Creators can now create commit pools; anyone can create additional standard pools
 
 ### Mainnet Deployment
 
@@ -770,10 +958,9 @@ To deploy to Bluechip Mainnet:
    ```bash
    ./deploy_mainnet.sh
    ```
-3. Update specific configurations in `deploy_mainnet.sh` (Oracle address, Price Feed ID) if necessary.
+3. Update specific configurations in `deploy_mainnet.sh` (Oracle address, Price Feed ID, expand-economy denom) if necessary.
 
 ---
-
 
 ## Links
 


### PR DESCRIPTION
The README still described the original "factory + single pool + expand-economy" three-contract layout. The protocol now ships:

  - factory/                          (orchestrator)
  - creator-pool/                     (commit + AMM)
  - standard-pool/                    (plain xyk AMM, new)
  - expand-economy/                   (bluechip mint reservoir)
  - packages/pool-core/               (shared AMM library)
  - packages/pool-factory-interfaces/ (shared wire-format types)

Updates:

  - Architecture diagram redrawn to show all four contracts plus the two shared packages, with creator-pool / standard-pool labelled explicitly and pool-core called out as the shared library both pool kinds depend on.
  - New "Pool Kinds" comparison table calls out which kind has the commit phase, mints CW20s, and participates in the expand-economy mint formula. Explicitly notes standard pools do NOT count toward the mint decay curve.
  - "Creating a Pool" split into Creator Pool (rate-limited 1h/address) and Standard Pool (permissionless, USD fee).
  - "Two-Phase Pool Lifecycle" scoped to creator-pool with a note that standard pools start in active-trading mode.
  - "Threshold Crossing" picked up the in-tx NFT auto-accept and the expand-economy notification step.
  - "NFT Liquidity Positions" now mentions the first-depositor MINIMUM_LIQUIDITY inflation lock and the standard-pool SubMsg balance-verification path with strict equality.
  - "Internal Oracle" picked up the warm-up gate, the per-update circuit breaker (30% drift cap), the cached eligible-pool snapshot (5-day refresh), and the keeper bounty.
  - "Integration Guide" added a CW20-allowance + DepositLiquidity example for standard-pool with a callout that fee-on-transfer CW20s revert via the verify reply.
  - "Security Considerations" rewritten to enumerate every audit defense without quoting tag IDs: shared reentrancy lock, oracle warm-up + circuit breaker, USD-capped keeper bounties, per-address pool-creation rate limit, SubMsg balance verification, strict fund collection, MINIMUM_LIQUIDITY first-deposit lock, auto-pause on low reserves, NFT pending-ownership window closed, migrate downgrade guard on every contract, two-phase emergency withdraw.
  - "Expand Economy" picked up the daily cap, factory-side denom cross-validation, nonpayable guard, denom format validation, and migrate handler. The mint formula's `x` is now correctly described as `commit_pool_ordinal` (commit-pool-only counter) rather than `pool_id`.
  - "Admin Operations" extended with force-rotate, anchor bootstrap, no-overwrite-of-pending-config, deduplicated pool_ids, anchor excluded from upgrade lists, and the universal migrate downgrade guard.
  - "Key Constants & Limits" updated to reflect the actual constants in code: 90s stale-price age (was 3000s), 30% TWAP drift cap, 6 warm-up observations, $0.10 USD bounty caps, 24h emergency withdraw timelock, 48h admin/expand-economy timelocks, 1h creator-pool create rate limit, 100k bluechip daily expansion cap, 1000 LP MINIMUM_LIQUIDITY, 2-block post-threshold cooldown, 10B oracle eligibility floor. Removed the stale `usd_payment_tolerance_bps` row (the field was deleted in audit).
  - Repository layout, deployment order, and test count rows added.

No tag IDs (H-N, M-N, etc.) appear in the README — flow and audit-derived improvements are presented as the protocol's current shape, consistent with the production-comment cleanup commits (fd9192f, 325cb14).

https://claude.ai/code/session_0146DzLg2D1rrVHC1Gr3YakL