### PR TITLE
audit(router): R1 strict CW20 balance reads + R7 48h admin timelock

### DIFF
--- a/packages/pool-factory-interfaces/src/asset.rs
+++ b/packages/pool-factory-interfaces/src/asset.rs
@@ -67,6 +67,34 @@ impl TokenType {
         }
     }
 
+    /// Strict variant of `query_pool`: propagates the underlying CW20
+    /// query error instead of swallowing it as a zero balance.
+    ///
+    /// Used by callers where a silent zero on a failed CW20 balance
+    /// query would corrupt downstream accounting — e.g. the router's
+    /// slippage assertion (`router::execution`), where pre/post balance
+    /// reads of the recipient's CW20 holdings need to fail-closed: a
+    /// swallowed pre-balance error would let the user's pre-existing
+    /// CW20 holdings count toward the post-route "received" total and
+    /// silently weaken slippage protection by up to that amount.
+    /// Native bank queries already propagate via the `?` in
+    /// `query_balance`, so the only behavioural difference is on the
+    /// CW20 side.
+    pub fn query_pool_strict(
+        &self,
+        querier: &QuerierWrapper,
+        pool_addr: Addr,
+    ) -> StdResult<Uint128> {
+        match self {
+            TokenType::CreatorToken { contract_addr, .. } => {
+                query_token_balance_strict(querier, contract_addr, &pool_addr)
+            }
+            TokenType::Native { denom, .. } => {
+                query_balance(querier, pool_addr, denom.to_string())
+            }
+        }
+    }
+
     pub fn equal(&self, asset: &TokenType) -> bool {
         match (self, asset) {
             (

--- a/router/src/contract.rs
+++ b/router/src/contract.rs
@@ -18,7 +18,7 @@ use crate::execution::{
 };
 use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
 use crate::simulation::simulate_multi_hop;
-use crate::state::{Config, CONFIG};
+use crate::state::{Config, PendingConfigUpdate, CONFIG, PENDING_CONFIG, ROUTER_TIMELOCK_SECONDS};
 
 const CONTRACT_NAME: &str = "crates.io:bluechip-router";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -68,10 +68,12 @@ pub fn execute(
             deadline,
             recipient,
         ),
-        ExecuteMsg::UpdateConfig {
+        ExecuteMsg::ProposeConfigUpdate {
             admin,
             factory_addr,
-        } => execute_update_config(deps, info, admin, factory_addr),
+        } => execute_propose_config_update(deps, env, info, admin, factory_addr),
+        ExecuteMsg::UpdateConfig {} => execute_apply_config_update(deps, env, info),
+        ExecuteMsg::CancelConfigUpdate {} => execute_cancel_config_update(deps, info),
         ExecuteMsg::Receive(cw20_msg) => execute_receive_cw20(deps, env, info, cw20_msg),
         ExecuteMsg::ExecuteSwapOperation {
             operation,
@@ -100,29 +102,106 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, RouterErro
     handle_reply(deps, env, msg)
 }
 
-fn execute_update_config(
+/// Step 1 of the 48h timelocked config rotation. Admin-only. Validates
+/// any address fields up front so a malformed proposal fails immediately
+/// instead of 48h later at apply.
+fn execute_propose_config_update(
     deps: DepsMut,
+    env: Env,
     info: MessageInfo,
     new_admin: Option<String>,
     new_factory_addr: Option<String>,
+) -> Result<Response, RouterError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.admin {
+        return Err(RouterError::Unauthorized);
+    }
+
+    // Reject re-propose while a prior proposal is still pending. Without
+    // this gate, a benign-looking proposal observed by the community
+    // could be silently swapped for a hostile one minutes before the
+    // window elapses; a watcher polling `PENDING_CONFIG` would see "still
+    // pending" without an explicit cancellation event in between.
+    if PENDING_CONFIG.may_load(deps.storage)?.is_some() {
+        return Err(RouterError::ConfigUpdateAlreadyPending);
+    }
+
+    // Early validation: addr_validate the candidate fields now so a
+    // malformed proposal fails at propose time rather than 48h later.
+    if let Some(addr) = &new_admin {
+        deps.api.addr_validate(addr)?;
+    }
+    if let Some(addr) = &new_factory_addr {
+        deps.api.addr_validate(addr)?;
+    }
+
+    let effective_after = env.block.time.plus_seconds(ROUTER_TIMELOCK_SECONDS);
+    PENDING_CONFIG.save(
+        deps.storage,
+        &PendingConfigUpdate {
+            admin: new_admin,
+            factory_addr: new_factory_addr,
+            effective_after,
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_attribute("action", "propose_config_update")
+        .add_attribute("effective_after", effective_after.to_string()))
+}
+
+/// Step 2 of the timelocked flow. Admin-only. Applies the pending
+/// proposal once `effective_after` has elapsed.
+fn execute_apply_config_update(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
 ) -> Result<Response, RouterError> {
     let mut config = CONFIG.load(deps.storage)?;
     if info.sender != config.admin {
         return Err(RouterError::Unauthorized);
     }
 
-    if let Some(admin) = new_admin {
+    let pending = PENDING_CONFIG
+        .may_load(deps.storage)?
+        .ok_or(RouterError::NoPendingConfigUpdate)?;
+
+    if env.block.time < pending.effective_after {
+        return Err(RouterError::TimelockNotExpired {
+            effective_after: pending.effective_after.seconds(),
+        });
+    }
+
+    if let Some(admin) = pending.admin {
         config.admin = deps.api.addr_validate(&admin)?;
     }
-    if let Some(factory) = new_factory_addr {
+    if let Some(factory) = pending.factory_addr {
         config.factory_addr = deps.api.addr_validate(&factory)?;
     }
+
     CONFIG.save(deps.storage, &config)?;
+    PENDING_CONFIG.remove(deps.storage);
 
     Ok(Response::new()
         .add_attribute("action", "update_config")
         .add_attribute("admin", config.admin)
         .add_attribute("factory_addr", config.factory_addr))
+}
+
+/// Cancels a pending proposal before its `effective_after`. Admin-only.
+fn execute_cancel_config_update(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, RouterError> {
+    let config = CONFIG.load(deps.storage)?;
+    if info.sender != config.admin {
+        return Err(RouterError::Unauthorized);
+    }
+    if PENDING_CONFIG.may_load(deps.storage)?.is_none() {
+        return Err(RouterError::NoPendingConfigUpdate);
+    }
+    PENDING_CONFIG.remove(deps.storage);
+    Ok(Response::new().add_attribute("action", "cancel_config_update"))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -63,4 +63,21 @@ pub enum RouterError {
 
     #[error("Slippage exceeded: minimum receive {minimum}, actual {actual}")]
     SlippageExceeded { minimum: Uint128, actual: Uint128 },
+
+    /// Config-update propose/apply timelock has not yet elapsed. Carries
+    /// the effective-after timestamp so callers can compute the wait.
+    #[error("Config update timelock not expired (effective after {effective_after})")]
+    TimelockNotExpired { effective_after: u64 },
+
+    /// `UpdateConfig` (apply) was called with no pending proposal. The
+    /// admin must run `ProposeConfigUpdate` first.
+    #[error("No pending config update; call ProposeConfigUpdate first")]
+    NoPendingConfigUpdate,
+
+    /// `ProposeConfigUpdate` was called while a prior pending proposal
+    /// still exists. The admin must `CancelConfigUpdate` first so that
+    /// any community watcher polling `PENDING_CONFIG` sees an explicit
+    /// cancellation event before a replacement proposal lands.
+    #[error("A config update is already pending; cancel it first via CancelConfigUpdate")]
+    ConfigUpdateAlreadyPending,
 }

--- a/router/src/execution.rs
+++ b/router/src/execution.rs
@@ -174,7 +174,14 @@ fn start_multi_hop(
     };
 
     let final_ask = operations.last().unwrap().ask_asset_info.clone();
-    let recipient_initial_balance = final_ask.query_pool(&deps.querier, recipient_addr.clone())?;
+    // Strict query (audit fix R1): on a CW20 final-ask, a swallowed
+    // pre-balance query would silently report zero and let the recipient's
+    // pre-existing CW20 holdings count toward the post-route "received"
+    // total — eroding slippage protection by up to that amount. The strict
+    // variant propagates query errors so a failed CW20 read fails the
+    // entire route closed instead of corrupting the assertion.
+    let recipient_initial_balance =
+        final_ask.query_pool_strict(&deps.querier, recipient_addr.clone())?;
 
     let last_idx = operations.len() - 1;
     let mut messages: Vec<SubMsg> = Vec::with_capacity(operations.len() + 1);
@@ -258,9 +265,14 @@ pub fn execute_swap_operation(
     }
     let to_addr = deps.api.addr_validate(&to)?;
 
+    // Strict query (audit fix R1). The router's own balance is what
+    // becomes the swap input for this hop; if a CW20 balance query
+    // silently returns zero on error we'd dispatch a zero-amount swap
+    // and the explicit zero-check below would mask the underlying
+    // query failure. Strict propagation surfaces the real cause.
     let offer_balance = operation
         .offer_asset_info
-        .query_pool(&deps.querier, env.contract.address.clone())?;
+        .query_pool_strict(&deps.querier, env.contract.address.clone())?;
     if offer_balance.is_zero() {
         return Err(RouterError::HopFailed {
             hop_index: hop_index as usize,
@@ -294,7 +306,11 @@ pub fn execute_assert_received(
         return Err(RouterError::Unauthorized);
     }
     let recipient_addr = deps.api.addr_validate(&recipient)?;
-    let current_balance = ask_info.query_pool(&deps.querier, recipient_addr.clone())?;
+    // Strict query (audit fix R1). Symmetric with the pre-route read in
+    // `start_multi_hop` — both must use the same strict variant so a
+    // CW20 query failure fails the assertion closed.
+    let current_balance =
+        ask_info.query_pool_strict(&deps.querier, recipient_addr.clone())?;
     let received = current_balance.checked_sub(prev_balance).map_err(|_| {
         RouterError::Std(StdError::generic_err(
             "recipient balance decreased during route; impossible state",

--- a/router/src/msg.rs
+++ b/router/src/msg.rs
@@ -50,13 +50,24 @@ pub enum ExecuteMsg {
         deadline: Option<Timestamp>,
         recipient: Option<String>,
     },
-    /// Admin-only configuration update. Both fields are optional so the
-    /// admin can rotate ownership independently of swapping the factory
-    /// reference (e.g. after a factory migration).
-    UpdateConfig {
+    /// Admin-only. Step 1 of a 48h-timelocked config change. Records a
+    /// `PendingConfigUpdate` with `effective_after = now + 48h`. Either
+    /// field may be `None` to leave that field unchanged. Re-proposing
+    /// while a pending proposal exists is rejected with
+    /// `ConfigUpdateAlreadyPending` — the admin must `CancelConfigUpdate`
+    /// first, so any community watcher polling `PENDING_CONFIG` sees an
+    /// explicit cancellation event before a replacement proposal lands.
+    ProposeConfigUpdate {
         admin: Option<String>,
         factory_addr: Option<String>,
     },
+    /// Admin-only. Step 2 of the timelocked flow. Applies the pending
+    /// proposal once `effective_after` has elapsed. Errors with
+    /// `NoPendingConfigUpdate` if no proposal is pending or
+    /// `TimelockNotExpired` if invoked too early.
+    UpdateConfig {},
+    /// Admin-only. Cancels a pending proposal before it can be applied.
+    CancelConfigUpdate {},
     /// CW20 entry path: triggered when a user invokes `cw20::Send`
     /// targeting the router with [`Cw20HookMsg::ExecuteMultiHop`] in the
     /// body. Used when the first hop offers a creator token rather than

--- a/router/src/state.rs
+++ b/router/src/state.rs
@@ -5,7 +5,7 @@
 //! router never serves stale liquidity, fee, or price information.
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Timestamp};
 use cw_storage_plus::Item;
 
 /// Hard cap on hops in a single route. Most real swaps are 2 hops
@@ -14,9 +14,19 @@ use cw_storage_plus::Item;
 /// letting callers chain unbounded transactions.
 pub const MAX_HOPS: usize = 3;
 
-/// Router configuration. The only mutable field is `admin`; the bluechip
-/// reserve denom and factory address are set at instantiation and
-/// changed only via [`crate::msg::ExecuteMsg::UpdateConfig`] by the admin.
+/// Timelock applied to admin-initiated config mutations on the router.
+/// Mirrors `factory::state::ADMIN_TIMELOCK_SECONDS`. Two days gives the
+/// community a full observability window to detect a compromised-admin
+/// rotation before it lands. The router holds no funds, so the practical
+/// blast radius of a hostile admin rotation is "lock the legitimate
+/// operator out of further config changes" — bounded but worth the
+/// timelock so a key compromise doesn't take effect instantly.
+pub const ROUTER_TIMELOCK_SECONDS: u64 = 86_400 * 2;
+
+/// Router configuration. Both fields are mutable, but only via the
+/// 48h-timelocked propose/apply flow
+/// (`ProposeConfigUpdate` -> wait -> `UpdateConfig`). Set at
+/// instantiate; changed only by the admin.
 #[cw_serde]
 pub struct Config {
     /// Bluechip factory address used to discover and validate pools.
@@ -30,3 +40,21 @@ pub struct Config {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
+
+/// Pending router-config update awaiting timelock expiry.
+///
+/// Either `admin` or `factory_addr` may be `None` (no change to that
+/// field). Re-proposing while a pending update exists is rejected; the
+/// admin must explicitly `CancelConfigUpdate` first so any community
+/// watcher polling `PENDING_CONFIG` always sees an explicit cancellation
+/// event before a different proposal replaces it.
+#[cw_serde]
+pub struct PendingConfigUpdate {
+    pub admin: Option<String>,
+    pub factory_addr: Option<String>,
+    pub effective_after: Timestamp,
+}
+
+/// Pending update awaiting `effective_after`. Cleared by
+/// `UpdateConfig` (apply) or `CancelConfigUpdate`.
+pub const PENDING_CONFIG: Item<PendingConfigUpdate> = Item::new("pending_config");

--- a/router/src/testing/integration_tests.rs
+++ b/router/src/testing/integration_tests.rs
@@ -813,16 +813,16 @@ fn commit_phase_pool_rejected_in_execution() {
 }
 
 #[test]
-fn update_config_admin_only() {
+fn propose_config_update_admin_only() {
     let mut world = setup_world();
 
-    // Non-admin attempt rejected.
+    // Non-admin propose: rejected.
     let err = world
         .app
         .execute_contract(
             world.user.clone(),
             world.router.clone(),
-            &RouterExecuteMsg::UpdateConfig {
+            &RouterExecuteMsg::ProposeConfigUpdate {
                 admin: Some(world.user.to_string()),
                 factory_addr: None,
             },
@@ -831,16 +831,118 @@ fn update_config_admin_only() {
         .unwrap_err();
     assert!(err.root_cause().to_string().contains("Unauthorized"));
 
-    // Admin can rotate.
+    // Admin propose: succeeds.
     world
         .app
         .execute_contract(
             world.admin.clone(),
             world.router.clone(),
-            &RouterExecuteMsg::UpdateConfig {
+            &RouterExecuteMsg::ProposeConfigUpdate {
                 admin: Some(world.user.to_string()),
                 factory_addr: None,
             },
+            &[],
+        )
+        .unwrap();
+
+    // Live config is unchanged at this point — only PENDING_CONFIG was
+    // written. Admin can still configure further (proposal hasn't applied).
+    let cfg: ConfigResponse = world
+        .app
+        .wrap()
+        .query_wasm_smart(&world.router, &RouterQueryMsg::Config {})
+        .unwrap();
+    assert_eq!(cfg.admin, world.admin);
+}
+
+#[test]
+fn update_config_before_timelock_rejected() {
+    let mut world = setup_world();
+
+    // Propose now.
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.user.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap();
+
+    // Try to apply immediately (no time advance): must reject with
+    // TimelockNotExpired.
+    let err = world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::UpdateConfig {},
+            &[],
+        )
+        .unwrap_err();
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("timelock not expired"),
+        "got: {err}"
+    );
+
+    // Live config still unchanged.
+    let cfg: ConfigResponse = world
+        .app
+        .wrap()
+        .query_wasm_smart(&world.router, &RouterQueryMsg::Config {})
+        .unwrap();
+    assert_eq!(cfg.admin, world.admin);
+}
+
+#[test]
+fn update_config_applies_after_timelock() {
+    let mut world = setup_world();
+
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.user.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap();
+
+    // Advance past the 48h timelock + 1s buffer.
+    world.app.update_block(|block| {
+        block.time = block
+            .time
+            .plus_seconds(crate::state::ROUTER_TIMELOCK_SECONDS + 1);
+    });
+
+    // Non-admin apply: still rejected (auth check is on apply too).
+    let err = world
+        .app
+        .execute_contract(
+            world.user.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::UpdateConfig {},
+            &[],
+        )
+        .unwrap_err();
+    assert!(err.root_cause().to_string().contains("Unauthorized"));
+
+    // Admin apply: succeeds, live config updates, pending clears.
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::UpdateConfig {},
             &[],
         )
         .unwrap();
@@ -852,4 +954,134 @@ fn update_config_admin_only() {
         .unwrap();
     assert_eq!(cfg.admin, world.user);
     assert_eq!(cfg.bluechip_denom, BLUECHIP_DENOM);
+}
+
+#[test]
+fn re_propose_while_pending_rejected() {
+    let mut world = setup_world();
+
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.user.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap();
+
+    // Re-propose while a prior proposal is still pending: rejected. The
+    // admin must explicitly cancel before re-proposing.
+    let err = world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.admin.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap_err();
+    assert!(
+        err.root_cause().to_string().contains("already pending"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn cancel_config_update_clears_pending() {
+    let mut world = setup_world();
+
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.user.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap();
+
+    // Non-admin cancel: rejected.
+    let err = world
+        .app
+        .execute_contract(
+            world.user.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::CancelConfigUpdate {},
+            &[],
+        )
+        .unwrap_err();
+    assert!(err.root_cause().to_string().contains("Unauthorized"));
+
+    // Admin cancel: succeeds.
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::CancelConfigUpdate {},
+            &[],
+        )
+        .unwrap();
+
+    // Cancel again: NoPendingConfigUpdate.
+    let err = world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::CancelConfigUpdate {},
+            &[],
+        )
+        .unwrap_err();
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("No pending config update"),
+        "got: {err}"
+    );
+
+    // After cancel, a fresh propose works (the gate is per-pending, not
+    // a one-shot).
+    world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ProposeConfigUpdate {
+                admin: Some(world.admin.to_string()),
+                factory_addr: None,
+            },
+            &[],
+        )
+        .unwrap();
+}
+
+#[test]
+fn apply_with_no_pending_rejected() {
+    let mut world = setup_world();
+    let err = world
+        .app
+        .execute_contract(
+            world.admin.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::UpdateConfig {},
+            &[],
+        )
+        .unwrap_err();
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("No pending config update"),
+        "got: {err}"
+    );
 }


### PR DESCRIPTION
Two findings from the router-crate audit pass.

R1 — CW20 balance queries on the slippage path swallow errors as zero ======================================================================

Defect:
  `TokenType::query_pool` (in pool-factory-interfaces) routes CW20
  balance reads through `query_token_balance`, which uses
  `.unwrap_or_else(|_| ...zero...)` — silently treating any query
  error as a zero balance. The router's slippage assertion
  (`execute_assert_received`) computes `received = post − pre`. If
  the pre-route read silently returned zero on error while the
  post-route read succeeded, the recipient's pre-existing CW20
  holdings would be swept into the "received" total, eroding
  slippage protection by up to that amount.

Fix:
  - Added `TokenType::query_pool_strict` on the strict variant, which uses `query_token_balance_strict` (already defined in asset.rs:164) that propagates query errors via `?`.
  - Switched the three router call sites to `query_pool_strict`:
      * `start_multi_hop:177` — recipient pre-route balance.
      * `execute_swap_operation:263` — router's per-hop offer balance. * `execute_assert_received:297` — recipient post-route balance.
  - Native bank reads were already strict via `query_balance` (uses `?`). The behavioural change is exclusively on the CW20 side.

R7 — admin rotation now goes through a 48h timelock ======================================================================

Defect:
  `UpdateConfig` was instant-apply: the admin could rotate `admin` and
  `factory_addr` with no observability window. Mirrors a gap that the
  factory closed via its `ProposeConfigUpdate -> UpdateConfig` flow.
  Router holds no funds so the practical blast radius of an instant
  hostile rotation was bounded ("lock the legitimate operator out"),
  but the propose/apply pattern is the same shape as the rest of the
  protocol's admin paths.

Fix:
  - New `state::PendingConfigUpdate { admin, factory_addr, effective_after }`.
  - New `state::PENDING_CONFIG: Item<PendingConfigUpdate>`.
  - New constant `state::ROUTER_TIMELOCK_SECONDS = 86_400 * 2`.
  - Restructured `ExecuteMsg`:
      * `ProposeConfigUpdate { admin, factory_addr }` — step 1, admin- only, validates address fields up front, rejects re-propose while a prior proposal is still pending (forces an explicit `CancelConfigUpdate` so community watchers see a cancellation event before any replacement).
      * `UpdateConfig {}` — step 2, admin-only, applies the pending proposal once `effective_after` has elapsed. * `CancelConfigUpdate {}` — admin-only, clears pending.
  - New `RouterError` variants: `TimelockNotExpired`, `NoPendingConfigUpdate`, `ConfigUpdateAlreadyPending`.
  - Both `ProposeConfigUpdate` and `UpdateConfig` apply `addr_validate` on the candidate addresses (early at propose AND at apply, so a stale proposal whose address was valid at propose time but truncated by chain-state changes still fails defensively).

Wire-format break: deployed router instances or tooling using the prior `UpdateConfig { admin, factory_addr }` shape need the new two-step flow. No deployed router instances exist on this branch.

Test coverage
==============

5 new router integration tests in
`router::testing::integration_tests`:
  - `propose_config_update_admin_only` — non-admin propose rejects; admin propose succeeds; live config unchanged at propose time.
  - `update_config_before_timelock_rejected` — apply called pre- timelock returns `TimelockNotExpired`; live config unchanged.
  - `update_config_applies_after_timelock` — after `+48h+1s`, apply succeeds; non-admin apply still rejects with `Unauthorized`; live config rotates; pending clears.
  - `re_propose_while_pending_rejected` — re-propose without cancel returns `ConfigUpdateAlreadyPending`.
  - `cancel_config_update_clears_pending` — admin can cancel; non-admin cannot; second cancel returns `NoPendingConfigUpdate`; fresh propose works after cancel.
  - `apply_with_no_pending_rejected` — apply with no pending returns `NoPendingConfigUpdate`.

Replaced the prior `update_config_admin_only` test (which exercised the now-removed instant-apply variant) with the propose/apply pair above.

R1 has no dedicated test added — exercising it requires a mock CW20 that selectively errors on balance queries, which is significant test infrastructure for a defensive-only change. The strict-vs-permissive behaviour is mechanical and the fix follows the established `query_token_balance_strict` precedent already used by the deposit balance verification path.

Workspace tests: 445 -> 450 (+5 new tests, all passing). Release build clean.

https://claude.ai/code/session_01Mw6jXNVoVJEmz2nQNR8Kar