### PR TITLE
test: pre-deploy coverage sweep — gap fills + warning cleanup

### DIFF
--- a/creator-pool/src/testing/creator_claim_tests.rs
+++ b/creator-pool/src/testing/creator_claim_tests.rs
@@ -237,3 +237,163 @@ fn retry_factory_notify_rejects_when_flag_false() {
     let err = execute_retry_factory_notify(deps.as_mut(), mock_env(), info).unwrap_err();
     assert!(matches!(err, ContractError::Std(_)));
 }
+
+// -- reply handler -------------------------------------------------------
+//
+// The pool's `reply` entry point handles two reply IDs:
+//   - REPLY_ID_FACTORY_NOTIFY_INITIAL (reply_on_error from
+//     trigger_threshold_payout): on Err, sets PENDING_FACTORY_NOTIFY
+//     so RetryFactoryNotify can be invoked later. On Ok, no-op
+//     (reply_on_error shouldn't fire on success but defensive).
+//   - REPLY_ID_FACTORY_NOTIFY_RETRY (reply_always from
+//     execute_retry_factory_notify): on Ok, clears PENDING_FACTORY_NOTIFY.
+//     On Err, keeps the flag set so another retry can be attempted.
+//
+// These tests build a synthetic Reply and invoke the handler directly,
+// exercising every branch of the matrix.
+
+mod reply_handler_tests {
+    use super::*;
+    use crate::contract::reply;
+    use crate::state::{REPLY_ID_FACTORY_NOTIFY_INITIAL, REPLY_ID_FACTORY_NOTIFY_RETRY};
+    use cosmwasm_std::{Binary, Reply, SubMsgResponse, SubMsgResult};
+
+    fn synthetic_reply(id: u64, ok: bool, err_msg: Option<&str>) -> Reply {
+        // SubMsgResponse.data is deprecated in favor of msg_responses on
+        // CosmWasm 2.0+, but the struct still requires the field for
+        // construction. Mirror the `#[allow(deprecated)]` pattern the
+        // factory's `pool_create_cleanup` uses where it parses replies.
+        #[allow(deprecated)]
+        let ok_response = SubMsgResponse {
+            events: vec![],
+            data: None,
+            msg_responses: vec![],
+        };
+        Reply {
+            id,
+            payload: Binary::default(),
+            gas_used: 0,
+            result: if ok {
+                SubMsgResult::Ok(ok_response)
+            } else {
+                SubMsgResult::Err(err_msg.unwrap_or("synthetic failure").to_string())
+            },
+        }
+    }
+
+    /// INITIAL_NOTIFY on Err: handler must set PENDING_FACTORY_NOTIFY=true
+    /// and emit `factory_notify_deferred` action attribute. Crucially must
+    /// return Ok (the parent commit tx must NOT revert just because the
+    /// factory notify failed — that's the entire point of reply_on_error).
+    #[test]
+    fn reply_initial_notify_on_error_sets_pending_flag() {
+        let mut deps = mock_dependencies();
+        setup_pool_storage(&mut deps);
+        // Confirm baseline: pending flag is unset / false.
+        assert!(!PENDING_FACTORY_NOTIFY
+            .may_load(&deps.storage)
+            .unwrap()
+            .unwrap_or(false));
+
+        let r = synthetic_reply(
+            REPLY_ID_FACTORY_NOTIFY_INITIAL,
+            false,
+            Some("factory rejected: pool not registered"),
+        );
+        let res = reply(deps.as_mut(), mock_env(), r).expect("reply must Ok on Err result");
+
+        assert!(res
+            .attributes
+            .iter()
+            .any(|a| a.key == "action" && a.value == "factory_notify_deferred"));
+        assert!(res
+            .attributes
+            .iter()
+            .any(|a| a.key == "reason"
+                && a.value.contains("factory rejected: pool not registered")));
+
+        // Pending flag is now armed — RetryFactoryNotify can be invoked.
+        assert!(PENDING_FACTORY_NOTIFY.load(&deps.storage).unwrap());
+    }
+
+    /// INITIAL_NOTIFY on Ok: defensive no-op path. reply_on_error
+    /// shouldn't normally produce Ok, but if a future runtime change
+    /// alters delivery semantics the handler must not panic. Returns
+    /// empty Response, leaves PENDING_FACTORY_NOTIFY untouched.
+    #[test]
+    fn reply_initial_notify_on_ok_is_noop() {
+        let mut deps = mock_dependencies();
+        setup_pool_storage(&mut deps);
+        // Pre-set to true to verify it's NOT touched on Ok.
+        PENDING_FACTORY_NOTIFY.save(&mut deps.storage, &true).unwrap();
+
+        let r = synthetic_reply(REPLY_ID_FACTORY_NOTIFY_INITIAL, true, None);
+        let res = reply(deps.as_mut(), mock_env(), r).expect("Ok branch must return Ok response");
+
+        // Empty response — no action attribute.
+        assert!(res.attributes.is_empty());
+        // Flag preserved.
+        assert!(PENDING_FACTORY_NOTIFY.load(&deps.storage).unwrap());
+    }
+
+    /// RETRY on Ok: handler clears PENDING_FACTORY_NOTIFY (the retry
+    /// succeeded) and emits `factory_notify_retry_succeeded`.
+    #[test]
+    fn reply_retry_on_ok_clears_pending_flag() {
+        let mut deps = mock_dependencies();
+        setup_pool_storage(&mut deps);
+        PENDING_FACTORY_NOTIFY.save(&mut deps.storage, &true).unwrap();
+
+        let r = synthetic_reply(REPLY_ID_FACTORY_NOTIFY_RETRY, true, None);
+        let res = reply(deps.as_mut(), mock_env(), r).expect("retry success path must Ok");
+
+        assert!(res
+            .attributes
+            .iter()
+            .any(|a| a.key == "action" && a.value == "factory_notify_retry_succeeded"));
+        assert!(!PENDING_FACTORY_NOTIFY.load(&deps.storage).unwrap());
+    }
+
+    /// RETRY on Err: handler must NOT propagate the error (would trap
+    /// gas in retry loop). Returns Ok, keeps the pending flag set so a
+    /// future retry can be attempted, emits `factory_notify_retry_failed`
+    /// with the failure reason for ops visibility.
+    #[test]
+    fn reply_retry_on_error_keeps_pending_flag() {
+        let mut deps = mock_dependencies();
+        setup_pool_storage(&mut deps);
+        PENDING_FACTORY_NOTIFY.save(&mut deps.storage, &true).unwrap();
+
+        let r = synthetic_reply(
+            REPLY_ID_FACTORY_NOTIFY_RETRY,
+            false,
+            Some("factory paused"),
+        );
+        let res = reply(deps.as_mut(), mock_env(), r)
+            .expect("retry failure must NOT propagate as Err — gas-trap risk");
+
+        assert!(res
+            .attributes
+            .iter()
+            .any(|a| a.key == "action" && a.value == "factory_notify_retry_failed"));
+        assert!(res
+            .attributes
+            .iter()
+            .any(|a| a.key == "reason" && a.value.contains("factory paused")));
+        // Flag stays set — caller can retry again later.
+        assert!(PENDING_FACTORY_NOTIFY.load(&deps.storage).unwrap());
+    }
+
+    /// Unknown reply ID returns Err. Defends against a future SubMsg
+    /// dispatch site forgetting to wire its reply handler — surfaces
+    /// the bug immediately rather than silently dropping the result.
+    #[test]
+    fn reply_unknown_id_returns_error() {
+        let mut deps = mock_dependencies();
+        setup_pool_storage(&mut deps);
+
+        let r = synthetic_reply(0xDEADBEEF, true, None);
+        let err = reply(deps.as_mut(), mock_env(), r).unwrap_err();
+        assert!(err.to_string().contains("Unknown reply id"));
+    }
+}

--- a/expand-economy/src/audit_tests.rs
+++ b/expand-economy/src/audit_tests.rs
@@ -806,4 +806,303 @@ mod tests {
             err
         );
     }
+
+    // -- Daily expansion cap + rolling window ----------------------------
+    //
+    // The daily cap is the primary defense against admin-compromise drain
+    // through the `RequestExpansion` path. These tests pin the contract's
+    // documented invariants:
+    //   - Total expansions in a 24h rolling window cannot exceed
+    //     DAILY_EXPANSION_CAP.
+    //   - The window is single-bucket-reset: when more than
+    //     DAILY_WINDOW_SECONDS elapses since `window_start`, the next
+    //     request resets `spent_in_window` to zero (acknowledged drift
+    //     vs a true sliding window — only LETS more through, never
+    //     blocks legitimately).
+    //   - Insufficient-balance graceful skip does NOT debit cap budget
+    //     (so a refund-then-retry doesn't permanently burn quota on a
+    //     payment that never landed).
+    //   - Sub-cap requests accumulate correctly across multiple calls.
+
+    use crate::state::{DAILY_EXPANSION_CAP, DAILY_WINDOW_SECONDS, EXPANSION_WINDOW};
+
+    /// A single request that exceeds the daily cap (fresh window) is
+    /// rejected with `DailyExpansionCapExceeded`. The window state is
+    /// untouched (no debit).
+    #[test]
+    fn daily_cap_rejects_single_request_exceeding_cap() {
+        let mut deps = mock_dependencies();
+        setup_contract(&mut deps);
+
+        let factory_addr = MockApi::default().addr_make("factory");
+        let user_addr = MockApi::default().addr_make("user");
+        install_factory_denom_mock(&mut deps, factory_addr.clone(), "ubluechip");
+
+        // Pre-fund the contract beyond the cap so the rejection is on
+        // the cap path, not the insufficient-balance fallback.
+        deps.querier
+            .bank
+            .update_balance(
+                &mock_env().contract.address,
+                coins(DAILY_EXPANSION_CAP.u128() + 1, "ubluechip"),
+            );
+
+        let over_cap = DAILY_EXPANSION_CAP + Uint128::new(1);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: over_cap,
+            }),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Daily expansion cap exceeded"),
+            "expected DailyExpansionCapExceeded, got: {}",
+            err
+        );
+        // Window unaffected by the rejected request.
+        let window = EXPANSION_WINDOW.may_load(&deps.storage).unwrap();
+        assert!(
+            window.is_none() || window.unwrap().spent_in_window.is_zero(),
+            "rejected request must not debit window"
+        );
+    }
+
+    /// Sub-cap requests accumulate; the call that would push total past
+    /// the cap rejects, prior debits remain.
+    #[test]
+    fn daily_cap_accumulates_then_rejects_overshoot() {
+        let mut deps = mock_dependencies();
+        setup_contract(&mut deps);
+
+        let factory_addr = MockApi::default().addr_make("factory");
+        let user_addr = MockApi::default().addr_make("user");
+        install_factory_denom_mock(&mut deps, factory_addr.clone(), "ubluechip");
+
+        deps.querier
+            .bank
+            .update_balance(
+                &mock_env().contract.address,
+                coins(DAILY_EXPANSION_CAP.u128() * 3, "ubluechip"),
+            );
+
+        // Three half-cap requests: the first two land, the third overshoots.
+        let half_cap = DAILY_EXPANSION_CAP.checked_div(Uint128::new(2)).unwrap();
+
+        // Call 1: spend half cap.
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: half_cap,
+            }),
+        )
+        .unwrap();
+        let w = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(w.spent_in_window, half_cap);
+
+        // Call 2: another (just-under) half — total is still <= cap, lands.
+        let just_under_half = half_cap - Uint128::new(1);
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: just_under_half,
+            }),
+        )
+        .unwrap();
+        let w = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(w.spent_in_window, half_cap + just_under_half);
+
+        // Call 3: another half — overshoots. Reject with prior debits
+        // intact.
+        let pre_call3 = w.spent_in_window;
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: half_cap,
+            }),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Daily expansion cap exceeded"));
+
+        // Window unchanged by the rejection.
+        let w_after = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(
+            w_after.spent_in_window, pre_call3,
+            "rejected request must not mutate spent_in_window"
+        );
+    }
+
+    /// After 24h+1s elapses, the next request resets the window and
+    /// can spend a fresh full-cap budget.
+    #[test]
+    fn daily_window_rolls_over_after_24h() {
+        let mut deps = mock_dependencies();
+        setup_contract(&mut deps);
+
+        let factory_addr = MockApi::default().addr_make("factory");
+        let user_addr = MockApi::default().addr_make("user");
+        install_factory_denom_mock(&mut deps, factory_addr.clone(), "ubluechip");
+
+        deps.querier
+            .bank
+            .update_balance(
+                &mock_env().contract.address,
+                coins(DAILY_EXPANSION_CAP.u128() * 3, "ubluechip"),
+            );
+
+        // Day-1 spend: half the cap.
+        let half_cap = DAILY_EXPANSION_CAP.checked_div(Uint128::new(2)).unwrap();
+        let env_day1 = mock_env();
+        execute(
+            deps.as_mut(),
+            env_day1.clone(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: half_cap,
+            }),
+        )
+        .unwrap();
+        let w = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(w.spent_in_window, half_cap);
+        let day1_window_start = w.window_start;
+
+        // Advance time past DAILY_WINDOW_SECONDS + 1s.
+        let mut env_day2 = env_day1.clone();
+        env_day2.block.time = env_day1.block.time.plus_seconds(DAILY_WINDOW_SECONDS + 1);
+
+        // Day-2 spend: the full cap. Should succeed because the window
+        // resets on the next call after expiry.
+        execute(
+            deps.as_mut(),
+            env_day2.clone(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: DAILY_EXPANSION_CAP,
+            }),
+        )
+        .unwrap();
+        let w = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(
+            w.spent_in_window, DAILY_EXPANSION_CAP,
+            "fresh window must accept a full-cap request after rollover"
+        );
+        assert_ne!(
+            w.window_start, day1_window_start,
+            "window_start must roll over to the new request's block time"
+        );
+    }
+
+    /// Insufficient-balance graceful skip MUST NOT debit cap budget.
+    /// If the contract balance is below the requested amount, the
+    /// handler returns Ok with the skip attribute but `spent_in_window`
+    /// stays unchanged — so a later refund + retry can spend that quota.
+    #[test]
+    fn insufficient_balance_skip_does_not_burn_cap() {
+        let mut deps = mock_dependencies();
+        setup_contract(&mut deps);
+
+        let factory_addr = MockApi::default().addr_make("factory");
+        let user_addr = MockApi::default().addr_make("user");
+        install_factory_denom_mock(&mut deps, factory_addr.clone(), "ubluechip");
+
+        // Contract has zero balance — request will skip on insufficient
+        // balance. Pre-set window state to verify it stays untouched.
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount: Uint128::new(1_000_000_000),
+            }),
+        )
+        .unwrap();
+        // Skipped, not paid. No BankMsg.
+        assert_eq!(res.messages.len(), 0);
+        let action = res
+            .attributes
+            .iter()
+            .find(|a| a.key == "action")
+            .unwrap();
+        assert_eq!(action.value, "request_reward_skipped");
+        let reason = res
+            .attributes
+            .iter()
+            .find(|a| a.key == "reason")
+            .unwrap();
+        assert_eq!(reason.value, "insufficient_balance");
+
+        // Window storage is untouched (no debit).
+        let window = EXPANSION_WINDOW.may_load(&deps.storage).unwrap();
+        assert!(
+            window.is_none(),
+            "skip path must not write any window state at all; got {:?}",
+            window
+        );
+    }
+
+    /// Successful request emits a BankMsg::Send for the right amount and
+    /// debits the window. Smoke test for the happy path that complements
+    /// the existing zero-amount and unauthorized tests.
+    #[test]
+    fn successful_request_sends_bank_msg_and_debits_window() {
+        let mut deps = mock_dependencies();
+        setup_contract(&mut deps);
+
+        let factory_addr = MockApi::default().addr_make("factory");
+        let user_addr = MockApi::default().addr_make("user");
+        install_factory_denom_mock(&mut deps, factory_addr.clone(), "ubluechip");
+
+        deps.querier
+            .bank
+            .update_balance(
+                &mock_env().contract.address,
+                coins(50_000_000, "ubluechip"),
+            );
+
+        let amount = Uint128::new(10_000_000);
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&factory_addr, &[]),
+            ExecuteMsg::ExpandEconomy(ExpandEconomyMsg::RequestExpansion {
+                recipient: user_addr.to_string(),
+                amount,
+            }),
+        )
+        .unwrap();
+
+        // Exactly one BankMsg::Send to the recipient for the right amount.
+        assert_eq!(res.messages.len(), 1);
+        match &res.messages[0].msg {
+            CosmosMsg::Bank(BankMsg::Send {
+                to_address,
+                amount: coins,
+            }) => {
+                assert_eq!(to_address, &user_addr.to_string());
+                assert_eq!(coins.len(), 1);
+                assert_eq!(coins[0].amount, amount);
+                assert_eq!(coins[0].denom, "ubluechip");
+            }
+            other => panic!("expected BankMsg::Send, got {:?}", other),
+        }
+
+        // Window debit equals the request amount.
+        let w = EXPANSION_WINDOW.load(&deps.storage).unwrap();
+        assert_eq!(w.spent_in_window, amount);
+    }
 }

--- a/factory/src/testing/audit_tests.rs
+++ b/factory/src/testing/audit_tests.rs
@@ -14,7 +14,7 @@ use crate::internal_bluechip_price_oracle::{
 };
 use crate::mock_querier::WasmMockQuerier;
 use crate::msg::{CreatorTokenInfo, ExecuteMsg};
-use crate::pool_struct::{CommitFeeInfo, CreatePool, PoolConfigUpdate, PoolDetails};
+use crate::pool_struct::{CreatePool, PoolConfigUpdate, PoolDetails};
 use crate::state::{
     EligiblePoolSnapshot, FactoryInstantiate, ELIGIBLE_POOL_SNAPSHOT, PENDING_CONFIG,
     POOLS_BY_CONTRACT_ADDRESS, POOLS_BY_ID, POOL_COUNTER, POOL_THRESHOLD_MINTED,
@@ -1827,9 +1827,7 @@ mod standard_pool_rate_limit_tests {
 mod anchor_bluechip_index_cache_tests {
     use super::*;
     use crate::internal_bluechip_price_oracle::INTERNAL_ORACLE;
-    use crate::state::{
-        EligiblePoolSnapshot, ELIGIBLE_POOL_SNAPSHOT, INITIAL_ANCHOR_SET, POOLS_BY_ID,
-    };
+    use crate::state::INITIAL_ANCHOR_SET;
 
     /// Register a Native/Native standard anchor pool with a chosen
     /// (bluechip, atom) ordering so we can drive both `index = 0` and
@@ -2214,6 +2212,455 @@ mod warmup_best_effort_tests {
         // works under the same setup).
         bluechip_to_usd(deps.as_ref(), amount, &env)
             .expect("bluechip_to_usd strict in steady state must succeed");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pool-admin forwarder tests (PausePool / UnpausePool / EmergencyWithdraw /
+//                             CancelEmergencyWithdraw / RecoverStuckStates)
+// ---------------------------------------------------------------------------
+//
+// These factory handlers forward an admin-issued message to the target pool
+// contract via WasmMsg::Execute. The pool itself rejects anything not from
+// `pool_info.factory_addr`, so the factory is the only entity that can issue
+// these. Tests here verify:
+//   - Auth gate: non-admin sender → Unauthorized.
+//   - Pool registry gate: unknown pool_id → "not found in registry".
+//   - Forwarding shape: admin sender → exactly one WasmMsg::Execute targeting
+//     the registered pool address with the right inner message.
+mod pool_admin_forwarder_tests {
+    use super::*;
+    use cosmwasm_std::{from_json, CosmosMsg, WasmMsg};
+    use serde::{Deserialize, Serialize};
+
+    /// Mirror of the factory's private `PoolAdminMsg` enum so tests can
+    /// decode and assert on the forwarded body. Wire format must stay in
+    /// lock-step with `factory/src/execute/pool_lifecycle/admin.rs`.
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    enum PoolAdminMsgMirror {
+        Pause {},
+        Unpause {},
+        EmergencyWithdraw {},
+        CancelEmergencyWithdraw {},
+        RecoverStuckStates {
+            recovery_type: crate::pool_struct::RecoveryType,
+        },
+    }
+
+    fn setup_factory_with_pool(pool_id: u64) -> (
+        OwnedDeps<MockStorage, MockApi, WasmMockQuerier>,
+        Addr,
+    ) {
+        let mut deps = mock_deps_with_querier(&[]);
+        setup_factory(&mut deps);
+        let pool_addr = make_addr(&format!("pool_{}", pool_id));
+        register_test_pool_addr(&mut deps.storage, pool_id, &pool_addr);
+        (deps, pool_addr)
+    }
+
+    fn assert_forwards_to_pool(
+        res: cosmwasm_std::Response,
+        expected_pool_addr: &Addr,
+        expected_inner: PoolAdminMsgMirror,
+    ) {
+        assert_eq!(res.messages.len(), 1, "expected exactly one forwarded msg");
+        match &res.messages[0].msg {
+            CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr,
+                msg,
+                funds,
+            }) => {
+                assert_eq!(contract_addr, &expected_pool_addr.to_string());
+                assert!(funds.is_empty(), "admin forwards must not attach funds");
+                let inner: PoolAdminMsgMirror = from_json(msg).unwrap();
+                assert_eq!(inner, expected_inner);
+            }
+            other => panic!("expected WasmMsg::Execute, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn pause_pool_admin_forwards_to_pool() {
+        let (mut deps, pool_addr) = setup_factory_with_pool(42);
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::PausePool { pool_id: 42 },
+        )
+        .unwrap();
+        assert_forwards_to_pool(res, &pool_addr, PoolAdminMsgMirror::Pause {});
+    }
+
+    #[test]
+    fn pause_pool_non_admin_rejected() {
+        let (mut deps, _) = setup_factory_with_pool(42);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&Addr::unchecked("hacker"), &[]),
+            ExecuteMsg::PausePool { pool_id: 42 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Only the admin"));
+    }
+
+    #[test]
+    fn pause_pool_unknown_pool_id_rejected() {
+        let (mut deps, _) = setup_factory_with_pool(42);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::PausePool { pool_id: 999 }, // not registered
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found in registry"));
+    }
+
+    #[test]
+    fn unpause_pool_admin_forwards_to_pool() {
+        let (mut deps, pool_addr) = setup_factory_with_pool(7);
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UnpausePool { pool_id: 7 },
+        )
+        .unwrap();
+        assert_forwards_to_pool(res, &pool_addr, PoolAdminMsgMirror::Unpause {});
+    }
+
+    #[test]
+    fn unpause_pool_non_admin_rejected() {
+        let (mut deps, _) = setup_factory_with_pool(7);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&Addr::unchecked("hacker"), &[]),
+            ExecuteMsg::UnpausePool { pool_id: 7 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Only the admin"));
+    }
+
+    #[test]
+    fn emergency_withdraw_admin_forwards_to_pool() {
+        let (mut deps, pool_addr) = setup_factory_with_pool(123);
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::EmergencyWithdrawPool { pool_id: 123 },
+        )
+        .unwrap();
+        assert_forwards_to_pool(res, &pool_addr, PoolAdminMsgMirror::EmergencyWithdraw {});
+    }
+
+    #[test]
+    fn emergency_withdraw_non_admin_rejected() {
+        let (mut deps, _) = setup_factory_with_pool(123);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&Addr::unchecked("hacker"), &[]),
+            ExecuteMsg::EmergencyWithdrawPool { pool_id: 123 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Only the admin"));
+    }
+
+    #[test]
+    fn cancel_emergency_withdraw_admin_forwards_to_pool() {
+        let (mut deps, pool_addr) = setup_factory_with_pool(456);
+        let res = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::CancelEmergencyWithdrawPool { pool_id: 456 },
+        )
+        .unwrap();
+        assert_forwards_to_pool(
+            res,
+            &pool_addr,
+            PoolAdminMsgMirror::CancelEmergencyWithdraw {},
+        );
+    }
+
+    #[test]
+    fn recover_stuck_states_admin_forwards_to_pool_with_recovery_type() {
+        let (mut deps, pool_addr) = setup_factory_with_pool(99);
+        // Each RecoveryType variant must round-trip through the forwarded
+        // payload — exercise all four.
+        for recovery in [
+            crate::pool_struct::RecoveryType::StuckThreshold,
+            crate::pool_struct::RecoveryType::StuckDistribution,
+            crate::pool_struct::RecoveryType::StuckReentrancyGuard,
+            crate::pool_struct::RecoveryType::Both,
+        ] {
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                message_info(&admin_addr(), &[]),
+                ExecuteMsg::RecoverPoolStuckStates {
+                    pool_id: 99,
+                    recovery_type: recovery.clone(),
+                },
+            )
+            .unwrap();
+            assert_forwards_to_pool(
+                res,
+                &pool_addr,
+                PoolAdminMsgMirror::RecoverStuckStates {
+                    recovery_type: recovery,
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn recover_stuck_states_non_admin_rejected() {
+        let (mut deps, _) = setup_factory_with_pool(99);
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&Addr::unchecked("hacker"), &[]),
+            ExecuteMsg::RecoverPoolStuckStates {
+                pool_id: 99,
+                recovery_type: crate::pool_struct::RecoveryType::StuckThreshold,
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Only the admin"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Anchor validation failure-mode tests
+// ---------------------------------------------------------------------------
+//
+// `validate_anchor_pool_choice` enforces the strict shape an anchor pool
+// must have: PoolKind::Standard, Native+Native pair of exactly
+// (bluechip_denom, atom_denom) in either order. The audit-fix
+// `anchor_bluechip_index_cache_tests` exercises the happy paths through
+// `SetAnchorPool`. These tests cover the rejection paths — the failure
+// modes that prevent a hostile or misconfigured anchor from being set.
+mod anchor_validation_failure_tests {
+    use super::*;
+    use crate::state::INITIAL_ANCHOR_SET;
+
+    fn fresh_factory_with_anchor_unset() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+        let mut deps = mock_deps_with_querier(&[]);
+        setup_factory(&mut deps);
+        // Reset one-shot guard so SetAnchorPool can fire.
+        INITIAL_ANCHOR_SET
+            .save(deps.as_mut().storage, &false)
+            .unwrap();
+        deps
+    }
+
+    /// SetAnchorPool against a Commit pool (not Standard) → rejected.
+    /// The anchor MUST be a standard pool because commit pools have a
+    /// pre-threshold phase where they can't serve swaps.
+    #[test]
+    fn set_anchor_rejects_commit_pool() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let pool_addr = make_addr("commit_pool_attempted_as_anchor");
+        // Register as Commit kind with the right denom pair shape.
+        let pool_details = PoolDetails {
+            pool_id: 50,
+            pool_token_info: [
+                TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                TokenType::Native {
+                    denom: "uatom".to_string(),
+                },
+            ],
+            creator_pool_addr: pool_addr,
+            pool_kind: pool_factory_interfaces::PoolKind::Commit, // wrong kind
+            commit_pool_ordinal: 0,
+        };
+        POOLS_BY_ID
+            .save(&mut deps.storage, 50, &pool_details)
+            .unwrap();
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 50 },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Anchor pool must be a standard pool"),
+            "got: {}",
+            err
+        );
+    }
+
+    /// SetAnchorPool against a Standard pool whose pair has a CreatorToken
+    /// instead of two Natives → rejected. Anchor must price ATOM/USD via
+    /// Pyth, and a CW20 side breaks that derivation.
+    #[test]
+    fn set_anchor_rejects_native_creator_pair() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let pool_addr = make_addr("std_native_creator_pool");
+        let pool_details = PoolDetails {
+            pool_id: 51,
+            pool_token_info: [
+                TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                TokenType::CreatorToken {
+                    contract_addr: Addr::unchecked("some_cw20"),
+                },
+            ],
+            creator_pool_addr: pool_addr,
+            pool_kind: pool_factory_interfaces::PoolKind::Standard,
+            commit_pool_ordinal: 0,
+        };
+        POOLS_BY_ID
+            .save(&mut deps.storage, 51, &pool_details)
+            .unwrap();
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 51 },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Anchor pool must be a Native/Native pair"),
+            "got: {}",
+            err
+        );
+    }
+
+    /// SetAnchorPool against a Standard Native+Native pool whose denoms
+    /// don't match `(bluechip_denom, atom_denom)` exactly → rejected.
+    /// Specifically a bluechip + IBC-not-atom pair: the pool has bluechip
+    /// on one side but the other side is an unrelated IBC denom. Anchor
+    /// must price ATOM/USD via Pyth, so any non-atom companion breaks
+    /// the derivation.
+    #[test]
+    fn set_anchor_rejects_bluechip_with_wrong_companion_denom() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let pool_addr = make_addr("std_bluechip_wrongibc_pool");
+        let pool_details = PoolDetails {
+            pool_id: 52,
+            pool_token_info: [
+                TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                TokenType::Native {
+                    denom: "ibc/UNRELATED_DENOM".to_string(), // not uatom
+                },
+            ],
+            creator_pool_addr: pool_addr,
+            pool_kind: pool_factory_interfaces::PoolKind::Standard,
+            commit_pool_ordinal: 0,
+        };
+        POOLS_BY_ID
+            .save(&mut deps.storage, 52, &pool_details)
+            .unwrap();
+
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 52 },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("Anchor pool must be a Native/Native pair"),
+            "got: {}",
+            err
+        );
+    }
+
+    /// SetAnchorPool against an unregistered pool_id → "not found in registry".
+    #[test]
+    fn set_anchor_rejects_unregistered_pool_id() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 9999 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("not found in registry"));
+    }
+
+    /// SetAnchorPool from a non-admin sender → Unauthorized.
+    #[test]
+    fn set_anchor_rejects_non_admin() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&Addr::unchecked("hacker"), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 1 },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Only the admin"));
+    }
+
+    /// One-shot guard: after a successful SetAnchorPool, a second call
+    /// (even from admin against a different valid pool) is rejected
+    /// because INITIAL_ANCHOR_SET is now true. Subsequent anchor changes
+    /// must go through the timelocked propose/apply config flow.
+    #[test]
+    fn set_anchor_one_shot_rejects_second_call() {
+        let mut deps = fresh_factory_with_anchor_unset();
+        let pool_addr_a = make_addr("first_anchor");
+        let pool_addr_b = make_addr("second_anchor_attempt");
+        for (pid, addr) in [(60, &pool_addr_a), (61, &pool_addr_b)] {
+            let pool_details = PoolDetails {
+                pool_id: pid,
+                pool_token_info: [
+                    TokenType::Native {
+                        denom: "ubluechip".to_string(),
+                    },
+                    TokenType::Native {
+                        denom: "uatom".to_string(),
+                    },
+                ],
+                creator_pool_addr: addr.clone(),
+                pool_kind: pool_factory_interfaces::PoolKind::Standard,
+                commit_pool_ordinal: 0,
+            };
+            POOLS_BY_ID
+                .save(&mut deps.storage, pid, &pool_details)
+                .unwrap();
+        }
+
+        // First call succeeds.
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 60 },
+        )
+        .unwrap();
+
+        // Second call rejects with the one-shot error.
+        let err = execute(
+            deps.as_mut(),
+            mock_env(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::SetAnchorPool { pool_id: 61 },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Anchor pool has already been set"),
+            "expected one-shot guard error, got: {}",
+            err
+        );
     }
 }
 

--- a/factory/src/testing/tests.rs
+++ b/factory/src/testing/tests.rs
@@ -21,7 +21,7 @@ use crate::internal_bluechip_price_oracle::{
 };
 use crate::mock_querier::{mock_dependencies, WasmMockQuerier};
 use crate::msg::{CreatorTokenInfo, ExecuteMsg};
-use crate::pool_struct::{CommitFeeInfo, CreatePool, PoolDetails, TempPoolCreation};
+use crate::pool_struct::{CreatePool, PoolDetails, TempPoolCreation};
 use cosmwasm_std::testing::{message_info, mock_env, MockApi, MockStorage};
 use pool_factory_interfaces::PoolStateResponseForFactory;
 
@@ -461,7 +461,10 @@ fn test_create_pair_with_custom_params() {
     let info = message_info(&admin_addr(), &[]);
     instantiate(deps.as_mut(), env, info, msg).unwrap();
 
-    let custom_params = Binary::from(b"custom_pool_params");
+    // (custom_params field on CreatePool was removed in the audit refactor —
+    // see `pool_struct::CreatePool` doc-comment. Caller-supplied threshold
+    // params are no longer honored; the factory config is the single source
+    // of truth. This test now exercises the simplified shape.)
 
     let create_msg = ExecuteMsg::Create {
         pool_msg: CreatePool { pool_token_info: [

--- a/factory/src/testing/update_tests.rs
+++ b/factory/src/testing/update_tests.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::testing::{
     MOCK_CONTRACT_ADDR,
 };
 use cosmwasm_std::{
-    from_json, to_json_binary, Addr, Coin, CosmosMsg, Decimal, Empty, OwnedDeps, Uint128, WasmMsg,
+    to_json_binary, Addr, Coin, CosmosMsg, Decimal, Empty, OwnedDeps, Uint128, WasmMsg,
 };
 
 use crate::asset::TokenType;


### PR DESCRIPTION
Final test review before local-chain deployment. Identified +4 stale import / dead-variable warnings and four production paths that were production-implemented but lacked direct test coverage. Added 26 new tests across three crates; fixed 4 warnings. Workspace 450 -> 476.

Stale-import / dead-variable cleanup
====================================

- factory/src/testing/tests.rs: dropped unused `CommitFeeInfo` import; replaced unused `custom_params` local with a comment referencing the audit-fix that removed the corresponding `CreatePool` field.
- factory/src/testing/audit_tests.rs: dropped unused `CommitFeeInfo` import (file level); dropped duplicate `EligiblePoolSnapshot` / `ELIGIBLE_POOL_SNAPSHOT` imports inside the `anchor_bluechip_index_cache_tests` module (already in scope via `use super::*`).
- factory/src/testing/update_tests.rs: dropped unused `from_json` import.

The four warnings these resolved were flagging actual stale code (removed fields, duplicate imports). The two remaining warnings (`mockoracle::entry_point` and `creator-pool::mock_querier::with_balance`) are pre-existing and not audit-related — left alone.

Coverage gap #1 — creator-pool reply handler (5 new tests) ==========================================================

`creator-pool/src/contract.rs::reply` handles two reply IDs across four behavioural cases. None had direct tests.

Added `creator_claim_tests::reply_handler_tests`:
  - `reply_initial_notify_on_error_sets_pending_flag` — the load-bearing case: factory notify failed -> set PENDING_FACTORY_NOTIFY=true, return Ok so the threshold-cross commit doesn't revert.
  - `reply_initial_notify_on_ok_is_noop` — defensive: reply_on_error shouldn't fire on success but if a future runtime change alters delivery semantics the handler must not panic.
  - `reply_retry_on_ok_clears_pending_flag` — retry succeeded -> clear the deferred-notify flag.
  - `reply_retry_on_error_keeps_pending_flag` — retry failed -> keep the flag set so a future retry can be attempted; MUST NOT propagate Err (would trap gas in retry loops).
  - `reply_unknown_id_returns_error` — guards against a future SubMsg dispatch site forgetting to wire its reply handler.

Coverage gap #2 — expand-economy daily cap (5 new tests) ========================================================

The daily expansion cap is the primary defense against admin-compromise drain through the `RequestExpansion` path, but had ZERO direct test coverage of the cap or rolling-window behaviour.

Added `audit_tests::tests`:
  - `daily_cap_rejects_single_request_exceeding_cap` — single request over `DAILY_EXPANSION_CAP` is rejected; window state untouched (no debit on rejected request).
  - `daily_cap_accumulates_then_rejects_overshoot` — sub-cap requests accumulate; the overshooting call rejects with prior debits intact.
  - `daily_window_rolls_over_after_24h` — after `DAILY_WINDOW_SECONDS` elapses, the next request resets the window and can spend a fresh full-cap budget.
  - `insufficient_balance_skip_does_not_burn_cap` — graceful skip path must NOT debit cap budget so a refund-then-retry doesn't burn quota on a payment that never landed.
  - `successful_request_sends_bank_msg_and_debits_window` — happy path: BankMsg::Send to recipient for the right amount, window debited correctly.

Coverage gap #3 — factory pool-admin forwarders (10 new tests) ==============================================================

The factory's `execute_pause_pool`, `execute_unpause_pool`, `execute_emergency_withdraw_pool`, `execute_cancel_emergency_withdraw_pool`, and `execute_recover_pool_stuck_states` handlers had zero direct tests on the factory side. Pool-side handlers were tested but the factory's auth + pool-registry-lookup + WasmMsg::Execute forwarding shape weren't.

Added `audit_tests::pool_admin_forwarder_tests` with a private `PoolAdminMsgMirror` enum that decodes and asserts on the forwarded inner message body:
  - pause_pool / unpause_pool: admin-forwards-to-pool (success), non-admin-rejected, unknown-pool-id-rejected (pause only since the gate is identical across all five forwarders).
  - emergency_withdraw / cancel_emergency_withdraw: admin-forwards
    + non-admin-rejected.
  - recover_stuck_states: admin-forwards-with-recovery-type that iterates through all four `RecoveryType` variants (StuckThreshold, StuckDistribution, StuckReentrancyGuard, Both) to verify they round-trip through the JSON payload correctly.
  - recover_stuck_states_non_admin_rejected.

Coverage gap #4 — anchor validation failure modes (6 new tests) ===============================================================

`validate_anchor_pool_choice` enforces strict shape: PoolKind::Standard, Native+Native pair of exactly (bluechip_denom, atom_denom). The audit-fix `anchor_bluechip_index_cache_tests` covers happy paths through SetAnchorPool. The rejection paths weren't tested.

Added `audit_tests::anchor_validation_failure_tests`:
  - `set_anchor_rejects_commit_pool` — wrong PoolKind.
  - `set_anchor_rejects_native_creator_pair` — Native+CreatorToken pair (anchor must be Native+Native).
  - `set_anchor_rejects_bluechip_with_wrong_companion_denom` — bluechip paired with an unrelated IBC denom (must be paired with `atom_denom` specifically).
  - `set_anchor_rejects_unregistered_pool_id` — pool_id not in registry.
  - `set_anchor_rejects_non_admin` — auth gate.
  - `set_anchor_one_shot_rejects_second_call` — INITIAL_ANCHOR_SET is a one-shot guard; subsequent anchor changes must go through the timelocked propose/apply config flow.

Workspace results
=================

cargo test --workspace --lib: **476 passed, 0 failed** (was 450).
  - factory: 145 -> 161 (+16)
  - creator-pool: 169 -> 174 (+5)
  - expand-economy: 29 -> 34 (+5)
  - pool-core / standard-pool / router: unchanged
cargo build --workspace --release: clean, no new warnings.

https://claude.ai/code/session_01Mw6jXNVoVJEmz2nQNR8Kar