### PR TITLE
Align FRONTEND_MIGRATION guide with current pool/factory wire format

### DIFF
--- a/docs/FRONTEND_MIGRATION.md
+++ b/docs/FRONTEND_MIGRATION.md
@@ -432,10 +432,14 @@ async function handleBuy() {
                     info:   { bluechip: { denom: BLUECHIP_CONFIG.nativeDenom } },
                     amount: microAmount
                 },
-                belief_price:         null,
-                max_spread:           spreadInput || null,
-                to:                   null,
-                transaction_deadline: deadlineNs
+                belief_price:          null,
+                max_spread:            spreadInput || null,
+                // Set to true to bypass the pool's spread safety cap. Leave
+                // null in the standard buy flow; only flip on if the user
+                // has explicitly opted into a higher max_spread than the cap.
+                allow_high_max_spread: null,
+                to:                    null,
+                transaction_deadline:  deadlineNs
             }
         };
 
@@ -556,10 +560,13 @@ async function handleSell() {
         // Build the inner swap hook message
         var hookMsg = {
             swap: {
-                belief_price:         null,
-                max_spread:           spreadInput || null,
-                to:                   null,
-                transaction_deadline: deadlineNs
+                belief_price:          null,
+                max_spread:            spreadInput || null,
+                // Same semantics as simple_swap.allow_high_max_spread; leave
+                // null unless you've surfaced an explicit override to the user.
+                allow_high_max_spread: null,
+                to:                    null,
+                transaction_deadline:  deadlineNs
             }
         };
 
@@ -696,12 +703,16 @@ async function handleAddLiquidity() {
 
         var tokenAddress   = null;
         var bluechipDenom  = BLUECHIP_CONFIG.nativeDenom;
-        for (var i = 0; i < pairInfo.asset_infos.length; i++) {
-            if (pairInfo.asset_infos[i].creator_token) {
-                tokenAddress = pairInfo.asset_infos[i].creator_token.contract_addr;
+        // Pair queries return the asset list under `pool_token_info` on
+        // current builds; older serialised state still surfaces it as
+        // `asset_infos`. Read either, falling back to an empty list.
+        var assets = pairInfo.pool_token_info || pairInfo.asset_infos || [];
+        for (var i = 0; i < assets.length; i++) {
+            if (assets[i].creator_token) {
+                tokenAddress = assets[i].creator_token.contract_addr;
             }
-            if (pairInfo.asset_infos[i].bluechip) {
-                bluechipDenom = pairInfo.asset_infos[i].bluechip.denom;
+            if (assets[i].bluechip) {
+                bluechipDenom = assets[i].bluechip.denom;
             }
         }
 
@@ -1099,16 +1110,22 @@ async function handleCollectFees() {
 
 ## 10. Create a Pool
 
-This lets anyone create a brand new creator pool with their own custom token. The pool goes through two phases:
+The factory exposes two distinct creation paths. Pick one based on what you want to ship:
 
-1. **Pre-Threshold (Funding Phase):** People commit Bluechip tokens. Only commits are accepted. No swaps yet.
-2. **Post-Threshold (Active Trading):** Once $25,000 USD in commits is reached, 1,200,000 creator tokens are minted and distributed:
+- **Commit (creator) pool** — factory `create` message. Mints a fresh CW20 creator token and starts the pool in a funding (commit) phase. Once the configured USD threshold is crossed, 1,200,000 creator tokens are minted and distributed:
    - **500,000** to early subscribers (proportional to their commits)
    - **325,000** to you, the creator
    - **25,000** to the BlueChip protocol
    - **350,000** seeded into the pool as initial liquidity
+- **Standard pool** — factory `create_standard_pool` message. Wraps two pre-existing assets in a plain xyk pool. No commit phase, no distribution. **One leg of the pair must be the canonical bluechip denom.**
 
-> **Important:** The wallet you use to create the pool becomes your creator wallet. **Do not lose your seed phrase** — BlueChip cannot recover it.
+> **Wire-format note:** The `pool_msg` body now carries **only** `pool_token_info`. Every other dial — commit threshold, fee splits, threshold-payout amounts, lock caps, oracle config — is sourced from the factory's stored config and silently overwrites anything a caller tries to send. Older guides that included `threshold_payout`, `commit_fee_info`, `cw20_token_contract_id`, `factory_to_create_pool_addr`, `pyth_*`, `max_bluechip_lock_per_pool`, `creator_excess_liquidity_lock_days`, or `is_standard_pool` are stale; the factory ignores those fields.
+
+> **Creation fee:** Both paths charge a USD-denominated creation fee paid in canonical bluechip. Attach the funds to the call (7th argument to `execute`); the factory verifies the amount, forwards the fee to the bluechip wallet, and refunds any surplus on-chain in the same tx.
+
+> **Validation bounds (commit pools):** Token name must be 3–50 printable ASCII characters; symbol must be 3–12 chars (A–Z, 0–9) with at least one letter; decimals are pinned to 6 (the threshold-payout amounts and CW20 mint cap are calibrated for this exact value).
+
+> **Important:** The wallet you use to create the pool becomes the creator wallet. **Do not lose your seed phrase** — BlueChip cannot recover it.
 
 ```html
 <!-- ============================================================ -->
@@ -1133,38 +1150,67 @@ This lets anyone create a brand new creator pool with their own custom token. Th
         </ul>
     </div>
 
-    <label style="display:block;margin-bottom:4px;font-weight:bold;">Token Name:</label>
-    <input id="pool-token-name" type="text" placeholder="e.g. My Creator Token"
-           style="width:100%;padding:10px;font-size:16px;border:1px solid #ccc;
-                  border-radius:6px;box-sizing:border-box;margin-bottom:12px;" />
-
-    <label style="display:block;margin-bottom:4px;font-weight:bold;">Token Symbol (Ticker):</label>
-    <input id="pool-token-symbol" type="text" placeholder="e.g. MCT" maxlength="10"
-           style="width:100%;padding:10px;font-size:16px;border:1px solid #ccc;
-                  border-radius:6px;box-sizing:border-box;margin-bottom:12px;
-                  text-transform:uppercase;" />
-
     <div style="margin-bottom:12px;">
         <label style="display:flex;align-items:center;gap:8px;cursor:pointer;">
             <input id="pool-standard" type="checkbox"
                    style="width:18px;height:18px;" />
             <span>
-                <strong>Standard Pool</strong>
+                <strong>Standard pool</strong>
                 <span style="color:#666;font-size:13px;display:block;">
-                    Skips commit phase. Starts with 0 liquidity — you must deposit manually.
+                    Wrap two pre-existing assets in a plain xyk pool. Skips the commit phase
+                    and creator-token mint; you must seed liquidity yourself.
                 </span>
             </span>
         </label>
     </div>
 
+    <!-- Commit (creator) pool inputs -->
+    <div id="pool-commit-inputs">
+        <label style="display:block;margin-bottom:4px;font-weight:bold;">Token Name:</label>
+        <input id="pool-token-name" type="text" placeholder="e.g. My Creator Token" maxlength="50"
+               style="width:100%;padding:10px;font-size:16px;border:1px solid #ccc;
+                      border-radius:6px;box-sizing:border-box;margin-bottom:4px;" />
+        <small style="color:#666;display:block;margin-bottom:12px;">3–50 printable ASCII characters.</small>
+
+        <label style="display:block;margin-bottom:4px;font-weight:bold;">Token Symbol (Ticker):</label>
+        <input id="pool-token-symbol" type="text" placeholder="e.g. MCT" maxlength="12"
+               style="width:100%;padding:10px;font-size:16px;border:1px solid #ccc;
+                      border-radius:6px;box-sizing:border-box;margin-bottom:4px;
+                      text-transform:uppercase;" />
+        <small style="color:#666;display:block;margin-bottom:12px;">3–12 chars, A–Z + 0–9, at least one letter.</small>
+    </div>
+
+    <!-- Standard pool inputs -->
+    <div id="pool-standard-inputs" style="display:none;">
+        <label style="display:block;margin-bottom:4px;font-weight:bold;">Asset 0:</label>
+        <input id="pool-asset0" type="text" value="ubluechip" placeholder="ubluechip or CW20 address"
+               style="width:100%;padding:10px;font-size:14px;border:1px solid #ccc;
+                      border-radius:6px;box-sizing:border-box;margin-bottom:4px;" />
+        <small style="color:#666;display:block;margin-bottom:12px;">Native bank denom (ubluechip, ibc/...) or CW20 contract address.</small>
+
+        <label style="display:block;margin-bottom:4px;font-weight:bold;">Asset 1:</label>
+        <input id="pool-asset1" type="text" placeholder="ubluechip / ibc/... / bluechip1..."
+               style="width:100%;padding:10px;font-size:14px;border:1px solid #ccc;
+                      border-radius:6px;box-sizing:border-box;margin-bottom:4px;" />
+        <small style="color:#666;display:block;margin-bottom:12px;">One asset MUST be the canonical bluechip denom (<code>ubluechip</code>).</small>
+
+        <label style="display:block;margin-bottom:4px;font-weight:bold;">Pool Label:</label>
+        <input id="pool-label" type="text" placeholder="e.g. ATOM/bluechip" maxlength="128"
+               style="width:100%;padding:10px;font-size:14px;border:1px solid #ccc;
+                      border-radius:6px;box-sizing:border-box;margin-bottom:12px;" />
+    </div>
+
+    <label style="display:block;margin-bottom:4px;font-weight:bold;">Creation Fee (ubluechip):</label>
+    <input id="pool-creation-fee" type="number" placeholder="micro-units of bluechip"
+           style="width:100%;padding:10px;font-size:14px;border:1px solid #ccc;
+                  border-radius:6px;box-sizing:border-box;margin-bottom:4px;" />
+    <small style="color:#666;display:block;margin-bottom:12px;">USD-denominated; attach the canonical-bluechip equivalent. The factory refunds any surplus on-chain.</small>
+
     <div style="padding:12px;background:#e3f2fd;border:1px solid #90caf9;border-radius:8px;
                 margin-bottom:16px;font-size:13px;">
-        <strong>Pool Configuration (Pre-set):</strong><br>
-        &bull; Commit Threshold: $25,000 USD<br>
-        &bull; Commit Fee: 1% BlueChip + 5% Creator<br>
-        &bull; Creator Token Supply: 1,200,000 (fixed, cannot mint more)<br>
-        &bull; Max BlueChip Lock: 10,000 tokens per pool<br>
-        &bull; Creator Excess Liquidity Lock: 7 days
+        <strong>Sourced from factory config (commit pools):</strong><br>
+        &bull; Commit threshold, fee splits, threshold-payout amounts, lock caps, oracle config<br>
+        &bull; Creator-token decimals are pinned to 6; mint cap pinned at 1,200,000 tokens
     </div>
 
     <button onclick="handleCreatePool()"
@@ -1179,6 +1225,14 @@ This lets anyone create a brand new creator pool with their own custom token. Th
 </div>
 
 <script>
+// Toggle the input groups in lockstep with the standard-pool checkbox so
+// the page never displays the wrong set of inputs for the active flow.
+document.getElementById("pool-standard").addEventListener("change", function (e) {
+    var standard = e.target.checked;
+    document.getElementById("pool-commit-inputs").style.display   = standard ? "none"  : "block";
+    document.getElementById("pool-standard-inputs").style.display = standard ? "block" : "none";
+});
+
 async function handleCreatePool() {
     var statusEl = document.getElementById("create-pool-status");
     var txEl     = document.getElementById("create-pool-tx");
@@ -1190,72 +1244,124 @@ async function handleCreatePool() {
         if (!connected) return;
     }
 
-    var tokenName   = document.getElementById("pool-token-name").value.trim();
-    var tokenSymbol = document.getElementById("pool-token-symbol").value.trim().toUpperCase();
-    var isStandard  = document.getElementById("pool-standard").checked;
+    var isStandard = document.getElementById("pool-standard").checked;
 
-    if (!tokenName || !tokenSymbol) {
-        statusEl.innerHTML = '<div style="color:red;">Please enter both a token name and symbol.</div>';
-        return;
-    }
+    // Caller-attached creation fee in ubluechip (canonical bluechip denom).
+    // The factory verifies it covers the USD-denominated fee converted via
+    // the oracle and refunds any surplus on-chain. Leave blank only if the
+    // factory has the fee disabled.
+    var creationFeeMicro =
+        (document.getElementById("pool-creation-fee").value || "").trim();
+    var funds = (creationFeeMicro && creationFeeMicro !== "0")
+        ? [{ denom: BLUECHIP_CONFIG.nativeDenom, amount: creationFeeMicro }]
+        : [];
 
     statusEl.innerHTML = '<div style="color:#1565c0;">Creating your pool... This may take a moment.</div>';
 
     try {
-        // Threshold payout distribution (in micro-units)
-        var thresholdPayout = {
-            creator_reward_amount: "325000000000",   // 325,000 tokens
-            bluechip_reward_amount: "25000000000",   // 25,000 tokens
-            pool_seed_amount: "350000000000",        // 350,000 tokens
-            commit_return_amount: "500000000000"     // 500,000 tokens to subscribers
-        };
-        var thresholdPayoutB64 = btoa(JSON.stringify(thresholdPayout));
+        var msg;
+        var memo;
 
-        var createMsg = {
-            create: {
-                pool_msg: {
-                    pool_token_info: [
-                        { bluechip: { denom: BLUECHIP_CONFIG.nativeDenom } },
-                        { creator_token: { contract_addr: "WILL_BE_CREATED_BY_FACTORY" } }
-                    ],
-                    cw20_token_contract_id:                1,
-                    factory_to_create_pool_addr:           BLUECHIP_CONFIG.factoryAddress,
-                    threshold_payout:                      thresholdPayoutB64,
-                    commit_fee_info: {
-                        bluechip_wallet_address: window.bluechipAddress,
-                        creator_wallet_address:  window.bluechipAddress,
-                        commit_fee_bluechip:     "0.01",
-                        commit_fee_creator:      "0.05"
-                    },
-                    creator_token_address:                 window.bluechipAddress,
-                    commit_amount_for_threshold:           "25000000000",
-                    commit_limit_usd:                      "25000000000",
-                    pyth_contract_addr_for_conversions:    "oracle_address_placeholder",
-                    pyth_atom_usd_price_feed_id:           "ATOM_USD",
-                    max_bluechip_lock_per_pool:            "10000000000",
-                    creator_excess_liquidity_lock_days:    7,
-                    is_standard_pool:                      isStandard
-                },
-                token_info: {
-                    name:    tokenName,
-                    symbol:  tokenSymbol,
-                    decimal: 6
-                }
+        if (!isStandard) {
+            // --- Commit (creator) pool ---
+            var tokenName   = document.getElementById("pool-token-name").value.trim();
+            var tokenSymbol = document.getElementById("pool-token-symbol").value.trim().toUpperCase();
+            if (!tokenName || !tokenSymbol) {
+                statusEl.innerHTML = '<div style="color:red;">Please enter both a token name and symbol.</div>';
+                return;
             }
-        };
+            // Mirror the factory's validate_creator_token_info bounds.
+            if (tokenName.length < 3 || tokenName.length > 50) {
+                statusEl.innerHTML = '<div style="color:red;">Token name must be 3–50 printable ASCII characters.</div>';
+                return;
+            }
+            if (!/^[A-Z0-9]{3,12}$/.test(tokenSymbol) || !/[A-Z]/.test(tokenSymbol)) {
+                statusEl.innerHTML = '<div style="color:red;">Token symbol must be 3–12 chars (A–Z, 0–9) with at least one letter.</div>';
+                return;
+            }
+
+            // CreatePool now carries ONLY pool_token_info — every other
+            // dial (commit threshold, fee splits, threshold payout amounts,
+            // lock caps, oracle config) is read from the factory's stored
+            // config and silently overwrites anything sent here. Order
+            // matters: bluechip at index 0, creator-token sentinel at index 1.
+            msg = {
+                create: {
+                    pool_msg: {
+                        pool_token_info: [
+                            { bluechip: { denom: BLUECHIP_CONFIG.nativeDenom } },
+                            { creator_token: { contract_addr: "WILL_BE_CREATED_BY_FACTORY" } }
+                        ]
+                    },
+                    token_info: {
+                        name:    tokenName,
+                        symbol:  tokenSymbol,
+                        // Decimals are pinned to 6; threshold-payout amounts
+                        // and the CW20 mint cap are calibrated for this value.
+                        decimal: 6
+                    }
+                }
+            };
+            memo = "Create Commit Pool";
+        } else {
+            // --- Standard (xyk) pool ---
+            var asset0 = document.getElementById("pool-asset0").value.trim();
+            var asset1 = document.getElementById("pool-asset1").value.trim();
+            var label  = document.getElementById("pool-label").value.trim();
+            if (!asset0 || !asset1 || !label) {
+                statusEl.innerHTML = '<div style="color:red;">Enter both assets and a label for the standard pool.</div>';
+                return;
+            }
+            if (asset0 === asset1) {
+                statusEl.innerHTML = '<div style="color:red;">Standard pool cannot pair an asset with itself.</div>';
+                return;
+            }
+
+            // Heuristic: contract addresses are bech32 (bluechip1.../cosmos1...)
+            // and longer than typical native denoms. Anything else is treated
+            // as a native bank denom (ubluechip, ibc/... wrapped assets, etc.).
+            function buildEntry(s) {
+                var looksLikeAddress = s.length > 20 && (s.indexOf("bluechip") === 0 || s.indexOf("cosmos") === 0);
+                return looksLikeAddress
+                    ? { creator_token: { contract_addr: s } }
+                    : { bluechip:      { denom:         s } };
+            }
+            var entry0 = buildEntry(asset0);
+            var entry1 = buildEntry(asset1);
+
+            // Factory enforces that one leg equal the canonical bluechip
+            // denom — surface this client-side for a faster error.
+            var hasCanonical =
+                (entry0.bluechip && entry0.bluechip.denom === BLUECHIP_CONFIG.nativeDenom) ||
+                (entry1.bluechip && entry1.bluechip.denom === BLUECHIP_CONFIG.nativeDenom);
+            if (!hasCanonical) {
+                statusEl.innerHTML =
+                    '<div style="color:red;">One asset must be the canonical bluechip denom (' +
+                    BLUECHIP_CONFIG.nativeDenom + ').</div>';
+                return;
+            }
+
+            msg = {
+                create_standard_pool: {
+                    pool_token_info: [entry0, entry1],
+                    label: label
+                }
+            };
+            memo = "Create Standard Pool";
+        }
 
         var result = await window.bluechipClient.execute(
             window.bluechipAddress,
             BLUECHIP_CONFIG.factoryAddress,
-            createMsg,
+            msg,
             { amount: [], gas: "2000000" },
-            "Create Pool"
+            memo,
+            funds
         );
 
         statusEl.innerHTML =
             '<div style="color:#2e7d32;font-weight:bold;">' +
-            'Pool created! Your token "' + tokenSymbol + '" is now live.<br>' +
-            'Share your pool address with fans so they can subscribe!' +
+            'Pool created! Share the pool address so people can interact with it.' +
             '</div>';
         txEl.innerHTML =
             '<div style="padding:10px;background:#fff3e0;border:1px solid #ff6f00;' +
@@ -1381,9 +1487,12 @@ async function getCreatorTokenAddress(poolAddress) {
 
     var pairInfo = await client.queryContractSmart(poolAddress, { pair: {} });
 
-    for (var i = 0; i < pairInfo.asset_infos.length; i++) {
-        if (pairInfo.asset_infos[i].creator_token) {
-            return pairInfo.asset_infos[i].creator_token.contract_addr;
+    // `pool_token_info` is the current field name; `asset_infos` remains
+    // as a fallback for legacy serialised state.
+    var assets = pairInfo.pool_token_info || pairInfo.asset_infos || [];
+    for (var i = 0; i < assets.length; i++) {
+        if (assets[i].creator_token) {
+            return assets[i].creator_token.contract_addr;
         }
     }
     return null;
@@ -1570,7 +1679,8 @@ After your pool is created, you can find the creator token address by querying:
 
 ```javascript
 var pairInfo = await client.queryContractSmart("YOUR_POOL_ADDRESS", { pair: {} });
-// Look for the creator_token entry in pairInfo.asset_infos
+// Look for the creator_token entry in pairInfo.pool_token_info
+// (older serialised state still surfaces it as pairInfo.asset_infos)
 ```
 
 Or check the pool creation transaction on your block explorer — the token contract address appears in the instantiation events.
@@ -1578,3 +1688,4 @@ Or check the pool creation transaction on your block explorer — the token cont
 ---
 
 **Questions?** Check the [BlueChip GitHub](https://github.com/Bluechip23/bluechip-contracts) or reach out to the BlueChip community.
+


### PR DESCRIPTION
- Section 10 (Create a Pool) rewritten end-to-end:
  * Document the two distinct factory entry points (commit-pool `create` vs standard-pool `create_standard_pool`) and the canonical-bluechip pair-shape requirement.
  * Drop every dead field the factory now silently overwrites (threshold_payout, commit_fee_info, cw20_token_contract_id, factory_to_create_pool_addr, pyth_*, max_bluechip_lock_per_pool, creator_excess_liquidity_lock_days, is_standard_pool) — pool_msg now carries only pool_token_info.
  * Add the USD-denominated creation fee to the JS handler (attached as canonical-bluechip funds; surplus refunded on-chain) and the matching form input.
  * Add a separate standard-pool input group (asset0/asset1/label) and a JS toggle that swaps it in when the standard checkbox is set.
  * Tighten token-name/symbol validation to the contract's bounds (3-50 ASCII / 3-12 A-Z+0-9 with at least one letter; decimals=6).
- Buy and Sell snippets now include allow_high_max_spread on simple_swap and the Cw20HookMsg::Swap hook respectively.
- Pair-query helpers (Add Liquidity + Get Creator Token Address + closing reference snippet) read pool_token_info first and fall back to asset_infos for legacy serialised state.