### PR TITLE
keepers: add retry-factory-notify + fold prune into oracle keeper

### DIFF
--- a/keepers/.env.example
+++ b/keepers/.env.example
@@ -33,9 +33,25 @@ KEEPER_MNEMONIC="twelve words of your keeper mnemonic here ..."
 # each 5-min factory cooldown window.
 # ORACLE_POLL_INTERVAL_MS=330000
 
+# Rate-limit prune sweep cadence (folded into the oracle keeper).
+# Once every N oracle iterations the keeper also dispatches
+# factory.PruneRateLimits {}. Default 200 × 5.5min ≈ 18h, so the sweep
+# fires roughly daily per process. Set to 0 to disable entirely.
+# ORACLE_PRUNE_EVERY_N=200
+
+# Per-call work cap passed to PruneRateLimits. Contract enforces a
+# hard ceiling of 500; default 100 is plenty for the steady-state
+# drift rate. Tune higher only for backlog catch-up after a long
+# prune outage.
+# PRUNE_BATCH_SIZE=100
+
 # Distribution keeper polling. Full sweep of POOL_ADDRESSES this often.
 # Defaults to 30 min. The keeper automatically speeds up to ~15s between
 # sweeps while a pool is actively distributing.
+# Each sweep also runs a retry-factory-notify pre-pass: each pool's
+# `FactoryNotifyStatus` is queried, and `RetryFactoryNotify` is dispatched
+# only on pools that report `pending=true`. No tunable knobs — the
+# work is gated by the same POOL_ADDRESSES list and DISTRIBUTION_POLL_INTERVAL_MS.
 # DISTRIBUTION_POLL_INTERVAL_MS=1800000
 
 # Small delay between pool calls during a sweep (so we don't hammer the

--- a/keepers/README.md
+++ b/keepers/README.md
@@ -116,12 +116,42 @@ every ORACLE_POLL_INTERVAL_MS (default 5.5 min):
     failed    → log error, keep going
   catch cooldown / beaten-to-the-punch errors as info-level
   warn if wallet balance < MIN_KEEPER_BALANCE_UBLUECHIP
+
+  # Folded-in maintenance sweep — see "Rate-limit prune" below.
+  every ORACLE_PRUNE_EVERY_N iterations (default 200 ≈ once per 18h):
+    submit factory.PruneRateLimits { batch_size: PRUNE_BATCH_SIZE }
 ```
+
+#### Rate-limit prune
+
+The factory tracks per-address create cooldowns in
+`LAST_COMMIT_POOL_CREATE_AT` and `LAST_STANDARD_POOL_CREATE_AT`. These
+maps grow monotonically — every new creator address adds an entry that
+is never removed by the cooldown logic itself. `PruneRateLimits` is a
+permissionless handler that removes entries older than 10× the cooldown
+(currently 10 hours). The oracle keeper dispatches it once every
+`ORACLE_PRUNE_EVERY_N` iterations rather than running a separate bot
+because:
+
+- there's no bounty (no economic reason to spin up a third process)
+- the cadence is wildly relaxed (daily is plenty)
+- the oracle keeper already runs on a fast loop and absorbs the gas
+  cost as part of "running keepers"
+
+Set `ORACLE_PRUNE_EVERY_N=0` to disable the sweep entirely (e.g., on a
+testnet where storage growth doesn't matter, or if you'd rather run
+prune from a separate cron).
 
 ### Distribution keeper
 
 ```
 every DISTRIBUTION_POLL_INTERVAL_MS (default 30 min):
+  # Pre-sweep: settle any stuck factory-notify state — see "Retry-notify" below.
+  for each pool in POOL_ADDRESSES:
+    query pool.FactoryNotifyStatus {}
+    if pending=true → submit pool.RetryFactoryNotify {}
+
+  # Main sweep: process pending committer payouts.
   for each pool in POOL_ADDRESSES:
     loop (bounded):
       submit pool.ContinueDistribution {}
@@ -133,6 +163,27 @@ every DISTRIBUTION_POLL_INTERVAL_MS (default 30 min):
 
 The per-pool inner loop is capped at 200 batches per sweep as a safety valve.
 Exceeding that is logged loudly — it means something is stuck.
+
+#### Retry-notify
+
+When a commit pool crosses its threshold, it dispatches
+`NotifyThresholdCrossed` to the factory as a `reply_on_error` SubMsg.
+If the factory rejects (e.g., transient expand-economy issue),
+`PENDING_FACTORY_NOTIFY` flips to `true` on the pool and the bluechip
+mint reward is held until somebody calls `RetryFactoryNotify`.
+
+The contract handler is permissionless on purpose — anyone can settle
+the stuck mint. The distribution keeper polls each pool's
+`FactoryNotifyStatus` query first and only spends gas on the (rare)
+pools that report `pending=true`. The factory's
+`POOL_THRESHOLD_MINTED` idempotency gate makes a redundant retry
+harmless: at worst the keeper wastes its own gas, never a double-mint.
+
+No bounty exists for this action; it's folded into the distribution
+keeper rather than running as a third bot because it iterates the same
+`POOL_ADDRESSES` list at a similar cadence and a 30-minute recovery
+latency on a stuck notify is fine — the failure mode is rare and not
+time-sensitive.
 
 ## Monitoring
 
@@ -146,6 +197,9 @@ Datadog, CloudWatch). The events you want to alert on:
 | `warn` | `keeper balance below threshold` | Top up the wallet. |
 | `warn` | `bounty skipped`, reason=`insufficient_factory_balance` | Top up the factory. |
 | `warn` | `bounty skipped`, reason=`price_unavailable` | Pyth outage. Check upstream. |
+| `error` | `retry_factory_notify errored` | Investigate — pool reported pending notify but retry failed for an unexpected reason. |
+| `warn` | `factory_notify_status query failed` | Single-pool RPC blip; ignore unless persistent. |
+| `warn` | `rate-limit prune errored (non-fatal)` | Investigate — prune is best-effort; persistent failures should be looked at. |
 
 And a liveness check: if you haven't seen an `oracle keeper starting` or
 `sleeping` log line from the oracle keeper in >15 minutes, assume it's
@@ -191,14 +245,23 @@ against a testnet:
 ```
 src/
 ├── lib/
-│   ├── config.ts        # env parsing (zod-validated)
-│   ├── client.ts        # CosmJS wallet + signing client
-│   ├── decisions.ts     # pure tx-outcome classification
-│   ├── logger.ts        # structured JSON output
-│   └── types.ts         # contract message shapes
+│   ├── config.ts             # env parsing (zod-validated)
+│   ├── client.ts             # CosmJS wallet + signing client
+│   ├── decisions.ts          # pure tx-outcome classification
+│   ├── logger.ts             # structured JSON output
+│   ├── types.ts              # contract message + query shapes
+│   ├── oracle-loop.ts        # one UpdateOraclePrice iteration
+│   ├── distribution-loop.ts  # per-pool ContinueDistribution drain
+│   ├── prune-loop.ts         # one PruneRateLimits iteration
+│   └── retry-notify-loop.ts  # query-then-retry per pool
 ├── __tests__/
 │   ├── config.test.ts
-│   └── decisions.test.ts
-├── oracle-keeper.ts          # entrypoint
-└── distribution-keeper.ts    # entrypoint
+│   ├── decisions.test.ts
+│   ├── oracle-keeper.mock-push.test.ts
+│   ├── distribution-keeper.integration.test.ts
+│   ├── prune-loop.test.ts
+│   ├── retry-notify-loop.test.ts
+│   └── factory-balance-check.test.ts
+├── oracle-keeper.ts          # entrypoint: oracle update + prune sweep
+└── distribution-keeper.ts    # entrypoint: retry-notify + distribution drain
 ```

--- a/keepers/src/__tests__/mock-contracts.ts
+++ b/keepers/src/__tests__/mock-contracts.ts
@@ -48,6 +48,21 @@ interface PoolState {
    * outages.
    */
   oracleUnavailable?: boolean;
+  /**
+   * Mirrors the on-chain `PENDING_FACTORY_NOTIFY` flag. True when the
+   * pool's threshold-cross commit landed but the factory-side
+   * NotifyThresholdCrossed SubMsg failed. RetryFactoryNotify clears
+   * this on success. Tests set it explicitly to drive the retry-notify
+   * keeper.
+   */
+  pendingFactoryNotify?: boolean;
+  /**
+   * If true, RetryFactoryNotify dispatches against this pool throw
+   * synthetically — e.g., simulating a still-failing factory side
+   * (idempotency error). Used to exercise the "tx_skip" expected-error
+   * branch of the retry-notify keeper.
+   */
+  retryFails?: boolean;
 }
 
 let txCounter = 0;
@@ -131,6 +146,43 @@ export class MockContracts implements Executor {
     this.unregisteredPools.add(address);
   }
 
+  /** Test hook: arm a pool's PENDING_FACTORY_NOTIFY flag. */
+  setPendingFactoryNotify(address: string, pending: boolean): void {
+    const pool = this.pools.get(address) ?? {
+      isDistributing: false,
+      batchesRemaining: 0,
+    };
+    pool.pendingFactoryNotify = pending;
+    this.pools.set(address, pool);
+  }
+
+  /** Test hook: future RetryFactoryNotify on this pool throws. */
+  failNextRetryNotify(address: string, fail: boolean = true): void {
+    const pool = this.pools.get(address) ?? {
+      isDistributing: false,
+      batchesRemaining: 0,
+    };
+    pool.retryFails = fail;
+    this.pools.set(address, pool);
+  }
+
+  /**
+   * Test hook: track every PruneRateLimits call dispatched against the
+   * factory so tests can assert cadence and batch_size threading.
+   */
+  public readonly pruneCalls: Array<{ batchSize: number }> = [];
+  /**
+   * Test hook: programmable counters returned by the next prune call.
+   * Defaults to (0, 0) — i.e., a steady-state "nothing to prune" sweep.
+   */
+  private nextPruneCounters: { commit: number; standard: number } = {
+    commit: 0,
+    standard: 0,
+  };
+  setNextPruneCounters(commit: number, standard: number): void {
+    this.nextPruneCounters = { commit, standard };
+  }
+
   /** Test hook: the next execute() against `address` throws. One-shot. */
   failNextExecute(address: string): void {
     this.failOnceAddresses.add(address);
@@ -171,13 +223,56 @@ export class MockContracts implements Executor {
     return 0n;
   }
 
+  async queryContractSmart<T>(contract: string, msg: Record<string, unknown>): Promise<T> {
+    if ("factory_notify_status" in msg) {
+      // Mirror creator-pool::query::query_factory_notify_status —
+      // returns { pending: bool } reading from the pool's
+      // PENDING_FACTORY_NOTIFY storage. We model "no pool entry" as
+      // pending=false, matching the contract's `unwrap_or(false)`.
+      const pool = this.pools.get(contract);
+      return { pending: pool?.pendingFactoryNotify ?? false } as unknown as T;
+    }
+    throw new Error(`mock query unsupported: ${JSON.stringify(msg)}`);
+  }
+
   // Factory handlers -----------------------------------------------------
 
   private executeFactory(msg: Record<string, unknown>): TxResult {
     if ("update_oracle_price" in msg) {
       return this.executeUpdateOraclePrice();
     }
+    if ("prune_rate_limits" in msg) {
+      return this.executePruneRateLimits(msg);
+    }
     throw new Error(`factory: unknown message ${JSON.stringify(msg)}`);
+  }
+
+  private executePruneRateLimits(msg: Record<string, unknown>): TxResult {
+    // Capture the batch_size so tests can assert it threaded through
+    // from PRUNE_BATCH_SIZE config.
+    const inner = (msg as { prune_rate_limits: { batch_size?: number } })
+      .prune_rate_limits;
+    const batchSize = inner?.batch_size ?? 100;
+    this.pruneCalls.push({ batchSize });
+
+    const counters = this.nextPruneCounters;
+    // Reset for next call to the steady-state default; tests opt back
+    // in via setNextPruneCounters.
+    this.nextPruneCounters = { commit: 0, standard: 0 };
+
+    return {
+      code: 0,
+      transactionHash: nextHash(),
+      events: [
+        wasmEvent([
+          ["action", "prune_rate_limits"],
+          ["commit_pruned", counters.commit.toString()],
+          ["standard_pruned", counters.standard.toString()],
+          ["stale_after_secs", "36000"],
+          ["batch_size", batchSize.toString()],
+        ]),
+      ],
+    };
   }
 
   private executeUpdateOraclePrice(): TxResult {
@@ -231,7 +326,44 @@ export class MockContracts implements Executor {
     if ("continue_distribution" in msg) {
       return this.executeContinueDistribution(poolAddress);
     }
+    if ("retry_factory_notify" in msg) {
+      return this.executeRetryFactoryNotify(poolAddress);
+    }
     throw new Error(`pool: unknown message ${JSON.stringify(msg)}`);
+  }
+
+  /**
+   * Mirror creator-pool::contract::execute_retry_factory_notify.
+   *
+   * Three behaviors:
+   *   - pool has no pending notify → throw the canonical
+   *     "No pending factory notification to retry" error (treated as
+   *     an expected skip by the keeper).
+   *   - pool's `retryFails` flag is set → throw a generic factory-side
+   *     error like "Bluechip mint already triggered" so we exercise
+   *     the keeper's tx_skip recovery branch.
+   *   - happy path → clear pendingFactoryNotify, emit attributes.
+   */
+  private executeRetryFactoryNotify(poolAddress: string): TxResult {
+    const pool = this.pools.get(poolAddress);
+    if (!pool || !pool.pendingFactoryNotify) {
+      throw new Error("No pending factory notification to retry");
+    }
+    if (pool.retryFails) {
+      pool.retryFails = false;
+      throw new Error("Bluechip mint already triggered for this pool");
+    }
+    pool.pendingFactoryNotify = false;
+    return {
+      code: 0,
+      transactionHash: nextHash(),
+      events: [
+        wasmEvent([
+          ["action", "retry_factory_notify"],
+          ["pool_id", "1"],
+        ]),
+      ],
+    };
   }
 
   private executeContinueDistribution(poolAddress: string): TxResult {

--- a/keepers/src/__tests__/prune-loop.test.ts
+++ b/keepers/src/__tests__/prune-loop.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MockContracts } from "./mock-contracts.js";
+import { runPruneIteration } from "../lib/prune-loop.js";
+
+const FACTORY = "bluechip1factory";
+const KEEPER = "bluechip1keeper";
+
+function makeClock() {
+  return { get: () => 1_700_000_000_000 };
+}
+
+describe("prune-loop iteration", () => {
+  let mock: MockContracts;
+
+  beforeEach(() => {
+    mock = new MockContracts(KEEPER, {
+      now: makeClock().get,
+      factoryAddress: FACTORY,
+    });
+  });
+
+  it("dispatches PruneRateLimits with the configured batch_size", async () => {
+    const outcome = await runPruneIteration(mock, FACTORY, 250);
+
+    expect(outcome.kind).toBe("pruned");
+    if (outcome.kind === "pruned") {
+      expect(outcome.txHash).toMatch(/^TX/);
+    }
+    expect(mock.pruneCalls).toHaveLength(1);
+    expect(mock.pruneCalls[0]?.batchSize).toBe(250);
+  });
+
+  it("parses commit_pruned + standard_pruned from response events", async () => {
+    mock.setNextPruneCounters(7, 3);
+
+    const outcome = await runPruneIteration(mock, FACTORY, 100);
+
+    expect(outcome.kind).toBe("pruned");
+    if (outcome.kind === "pruned") {
+      expect(outcome.commitPruned).toBe(7);
+      expect(outcome.standardPruned).toBe(3);
+    }
+  });
+
+  it("steady-state sweep returns zero counters without erroring", async () => {
+    // Most calls hit the steady state where there's nothing to prune.
+    // The keeper must treat "0 pruned" as a successful no-op, NOT as an
+    // error condition that warrants escalation.
+    const outcome = await runPruneIteration(mock, FACTORY, 100);
+    expect(outcome.kind).toBe("pruned");
+    if (outcome.kind === "pruned") {
+      expect(outcome.commitPruned).toBe(0);
+      expect(outcome.standardPruned).toBe(0);
+    }
+  });
+
+  it("survives an unexpected RPC error without throwing", async () => {
+    // Force the next factory execute to throw with a non-skip error.
+    mock.failNextExecute(FACTORY);
+
+    const outcome = await runPruneIteration(mock, FACTORY, 100);
+
+    // Critical: the prune sweep must NEVER bubble up — a failed prune
+    // must not break the oracle keeper's main loop. The implementation
+    // returns `errored` (logged at warn level) rather than throwing.
+    expect(outcome.kind).toBe("errored");
+    if (outcome.kind === "errored") {
+      expect(outcome.detail).toContain("forced failure");
+    }
+  });
+});

--- a/keepers/src/__tests__/retry-notify-loop.test.ts
+++ b/keepers/src/__tests__/retry-notify-loop.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { MockContracts } from "./mock-contracts.js";
+import {
+  checkAndRetryPool,
+  runRetryNotifySweep,
+} from "../lib/retry-notify-loop.js";
+
+const FACTORY = "bluechip1factory";
+const KEEPER = "bluechip1keeper";
+const POOL_A = "bluechip1pool_a";
+const POOL_B = "bluechip1pool_b";
+const POOL_C = "bluechip1pool_c";
+
+function makeClock(initialMs: number = 1_700_000_000_000) {
+  let t = initialMs;
+  return { get: () => t };
+}
+
+describe("retry-notify keeper", () => {
+  let mock: MockContracts;
+
+  beforeEach(() => {
+    mock = new MockContracts(KEEPER, {
+      now: makeClock().get,
+      factoryAddress: FACTORY,
+    });
+  });
+
+  it("skips a pool whose FactoryNotifyStatus reports pending=false", async () => {
+    // Default state: no pending. Most pools, most of the time.
+    const outcome = await checkAndRetryPool(mock, POOL_A);
+    expect(outcome.kind).toBe("skipped");
+    if (outcome.kind === "skipped") {
+      expect(outcome.reason).toBe("not_pending");
+    }
+    // Critical: the keeper must NOT dispatch RetryFactoryNotify on a
+    // pool that doesn't need it. The contract handler would reject
+    // with the canonical "No pending factory notification to retry"
+    // error, which would still be classified as a skip on our side
+    // — but it would consume gas. The query-first approach saves
+    // every wasted-gas tx in the steady state.
+    const retryCalls = mock.calls.filter(
+      (c) => c.contract === POOL_A && "retry_factory_notify" in c.msg,
+    );
+    expect(retryCalls).toHaveLength(0);
+  });
+
+  it("dispatches RetryFactoryNotify when pending=true", async () => {
+    mock.setPendingFactoryNotify(POOL_A, true);
+    const outcome = await checkAndRetryPool(mock, POOL_A);
+    expect(outcome.kind).toBe("retried");
+    if (outcome.kind === "retried") {
+      expect(outcome.txHash).toMatch(/^TX/);
+    }
+  });
+
+  it("treats a 'no pending notify' tx race as a clean skip", async () => {
+    // Race: query said pending=true, but state changed before the tx
+    // landed. The contract's "No pending factory notification to retry"
+    // error is in the SKIP_MARKERS list, so the keeper classifies as
+    // a skip rather than an error.
+    mock.setPendingFactoryNotify(POOL_A, true);
+    // Flip the flag back BEFORE the keeper's tx fires by intercepting
+    // queryContractSmart isn't available here; instead simulate by
+    // setting pending=true for the query but pre-clearing it with a
+    // direct setPendingFactoryNotify(false) just before checkAndRetryPool
+    // ... but that defeats the test. Easier: model the race directly
+    // by marking the pool pending then clearing inside a wrapped
+    // queryContractSmart-aware spy. Since our mock keeps state
+    // consistent, simulate the race with `failNextRetryNotify` (which
+    // throws "Bluechip mint already triggered") instead — same skip
+    // class.
+    mock.failNextRetryNotify(POOL_A, true);
+
+    const outcome = await checkAndRetryPool(mock, POOL_A);
+    expect(outcome.kind).toBe("skipped");
+    if (outcome.kind === "skipped" && outcome.reason === "tx_skip") {
+      expect(outcome.detail).toContain("Bluechip mint already triggered");
+    } else {
+      throw new Error(`expected tx_skip outcome, got ${JSON.stringify(outcome)}`);
+    }
+  });
+
+  it("reports query_failed when the read errors and does not dispatch a tx", async () => {
+    // Override queryContractSmart on the mock to throw once.
+    const original = mock.queryContractSmart.bind(mock);
+    let calls = 0;
+    mock.queryContractSmart = async <T,>(
+      contract: string,
+      msg: Record<string, unknown>,
+    ): Promise<T> => {
+      calls += 1;
+      if (calls === 1) throw new Error("RPC: connection reset");
+      return original<T>(contract, msg);
+    };
+
+    const outcome = await checkAndRetryPool(mock, POOL_A);
+    expect(outcome.kind).toBe("query_failed");
+    if (outcome.kind === "query_failed") {
+      expect(outcome.detail).toContain("RPC");
+    }
+    // No execute call should have fired.
+    const retryCalls = mock.calls.filter((c) => "retry_factory_notify" in c.msg);
+    expect(retryCalls).toHaveLength(0);
+  });
+
+  it("sweep continues past per-pool failures and aggregates totals", async () => {
+    mock.setPendingFactoryNotify(POOL_A, true);
+    // POOL_B is healthy, no pending.
+    mock.setPendingFactoryNotify(POOL_C, true);
+    mock.failNextRetryNotify(POOL_C, true); // simulate idempotency race
+
+    const result = await runRetryNotifySweep(mock, [POOL_A, POOL_B, POOL_C]);
+
+    // Order preserved.
+    expect(result.outcomes).toHaveLength(3);
+    expect(result.outcomes[0]?.pool).toBe(POOL_A);
+    expect(result.outcomes[1]?.pool).toBe(POOL_B);
+    expect(result.outcomes[2]?.pool).toBe(POOL_C);
+
+    expect(result.outcomes[0]?.kind).toBe("retried");
+    expect(result.outcomes[1]?.kind).toBe("skipped");
+    expect(result.outcomes[2]?.kind).toBe("skipped"); // tx_skip
+
+    expect(result.totals).toEqual({
+      retried: 1,
+      skipped: 2,
+      queryFailed: 0,
+      errored: 0,
+    });
+  });
+
+  it("clears the pending flag after a successful retry so the next sweep is a no-op", async () => {
+    mock.setPendingFactoryNotify(POOL_A, true);
+
+    const first = await runRetryNotifySweep(mock, [POOL_A]);
+    expect(first.totals.retried).toBe(1);
+
+    const second = await runRetryNotifySweep(mock, [POOL_A]);
+    expect(second.totals.retried).toBe(0);
+    expect(second.totals.skipped).toBe(1);
+    // Specifically: not_pending, not tx_skip (the contract didn't even
+    // get called the second time).
+    const o = second.outcomes[0];
+    expect(o?.kind).toBe("skipped");
+    if (o?.kind === "skipped") expect(o.reason).toBe("not_pending");
+  });
+});

--- a/keepers/src/distribution-keeper.ts
+++ b/keepers/src/distribution-keeper.ts
@@ -4,6 +4,7 @@ import { buildKeeperClient } from "./lib/client.js";
 import { nextDistributionSleepMs } from "./lib/decisions.js";
 import { runDistributionSweep } from "./lib/distribution-loop.js";
 import { checkFactoryBalance, checkKeeperBalance } from "./lib/oracle-loop.js";
+import { runRetryNotifySweep } from "./lib/retry-notify-loop.js";
 import { interruptibleSleep } from "./lib/sleep.js";
 import { log } from "./lib/logger.js";
 
@@ -34,6 +35,18 @@ async function main(): Promise<void> {
   process.on("SIGTERM", stop);
 
   while (!stopped) {
+    // Run the retry-factory-notify sweep BEFORE the distribution sweep.
+    // Order matters: a stuck factory-notify means POOL_THRESHOLD_MINTED
+    // never landed on the factory side, which blocks the bluechip
+    // mint reward but does NOT block distribution itself (distribution
+    // mints creator-tokens, which is a pool-side action). Still,
+    // settling the notify first means the same iteration can leave
+    // the pool fully consistent rather than half. Each pool's
+    // RetryFactoryNotify is itself permissionless and idempotent on
+    // the factory side (POOL_THRESHOLD_MINTED gate), so a redundant
+    // call is at worst wasted gas — never a double-mint.
+    await runRetryNotifySweep(client, cfg.POOL_ADDRESSES);
+
     const { madeProgress } = await runDistributionSweep(
       client,
       cfg.POOL_ADDRESSES,

--- a/keepers/src/lib/client.ts
+++ b/keepers/src/lib/client.ts
@@ -52,6 +52,13 @@ export async function buildKeeperClient(cfg: Config): Promise<KeeperClient> {
       const coin = await signer.getBalance(target, denom);
       return BigInt(coin.amount);
     },
+    async queryContractSmart<T>(contract: string, msg: Record<string, unknown>): Promise<T> {
+      // SigningCosmWasmClient extends CosmWasmClient, which exposes
+      // queryContractSmart. The CosmJS return type is `unknown`; we
+      // assert to `T` here and trust the caller to declare the right
+      // shape (matching the contract's `#[returns(...)]` annotation).
+      return (await signer.queryContractSmart(contract, msg)) as T;
+    },
     close: () => signer.disconnect(),
   };
 }

--- a/keepers/src/lib/config.ts
+++ b/keepers/src/lib/config.ts
@@ -80,6 +80,20 @@ export const ConfigSchema = z.object({
   // Oracle keeper tuning
   ORACLE_POLL_INTERVAL_MS: positiveIntString({ default: "330000" }), // 5.5 min
 
+  // Rate-limit prune sweep cadence (folded into the oracle keeper).
+  // Once every N oracle iterations the keeper also dispatches
+  // factory.PruneRateLimits {}. Default 200 × 5.5min ≈ 18h, so the
+  // sweep runs roughly daily per process. Set to 0 to disable
+  // entirely (e.g., for testnets where rate-limit growth doesn't
+  // matter or for ops who'd rather run prune as a separate cron).
+  ORACLE_PRUNE_EVERY_N: positiveIntString({ allowZero: true, default: "200" }),
+  // Per-call work cap passed to PruneRateLimits. Contract enforces a
+  // hard ceiling of 500; we default to 100 which is plenty for the
+  // expected drift rate (≪ 100 stale entries per day on a healthy
+  // protocol). Tunable upward for backlog catch-up after a long
+  // prune outage.
+  PRUNE_BATCH_SIZE: positiveIntString({ default: "100" }),
+
   // Distribution keeper tuning
   DISTRIBUTION_POLL_INTERVAL_MS: positiveIntString({ default: "1800000" }), // 30 min
   // 0 means "no breather"; default is a 2s pause between pool calls so we

--- a/keepers/src/lib/executor.ts
+++ b/keepers/src/lib/executor.ts
@@ -29,4 +29,18 @@ export interface Executor {
    * operators can top up before bounties start getting skipped.
    */
   getAddressBalance(address: string, denom: string): Promise<bigint>;
+
+  /**
+   * Read-only smart query against a contract. Used by the
+   * retry-factory-notify keeper to poll each pool's
+   * `FactoryNotifyStatus` query before deciding whether to dispatch a
+   * RetryFactoryNotify tx. Querying first means we only spend gas on
+   * the (rare) pools that actually need a retry rather than blasting
+   * every pool every round.
+   *
+   * `T` is the deserialised JSON shape the contract returns for `msg`.
+   * Errors propagate so callers can decide policy (ignore-and-skip vs
+   * propagate-and-stop).
+   */
+  queryContractSmart<T>(contract: string, msg: Record<string, unknown>): Promise<T>;
 }

--- a/keepers/src/lib/prune-loop.ts
+++ b/keepers/src/lib/prune-loop.ts
@@ -1,0 +1,108 @@
+// PruneRateLimits sweep — folded into the oracle keeper.
+//
+// Background: the factory's `LAST_COMMIT_POOL_CREATE_AT` and
+// `LAST_STANDARD_POOL_CREATE_AT` maps are keyed on `info.sender`. They
+// grow by one entry every successful Create / CreateStandardPool call
+// and never shrink on their own. Over years of operation this becomes
+// soft storage bloat — entries from addresses that created one pool
+// and disappeared.
+//
+// `factory.PruneRateLimits { batch_size }` is permissionless and removes
+// entries older than 10× the cooldown window (so 10h today). We don't
+// run it as its own bot because:
+//   - It has no bounty (no economic incentive to spin up a dedicated process).
+//   - Cadence is wildly relaxed (daily would be plenty).
+//   - The oracle keeper already runs every ~5 min and is the natural
+//     place to tack on a low-frequency sweep.
+//
+// We dispatch the prune once every `ORACLE_PRUNE_EVERY_N` iterations of
+// the oracle keeper. With the default 5.5min poll * 200 = ~18h, the
+// sweep fires roughly once a day per process.
+
+import type { Executor } from "./executor.js";
+import { factoryExecPruneRateLimits, isExpectedSkipError } from "./types.js";
+import { log } from "./logger.js";
+
+/**
+ * Decision shape of one PruneRateLimits attempt.
+ *
+ * `pruned_*` counts are extracted from the contract's response
+ * attributes (`commit_pruned`, `standard_pruned`). They will both be
+ * zero on most calls — that's the steady-state when nothing has gone
+ * stale yet.
+ */
+export type PruneOutcome =
+  | { kind: "pruned"; txHash: string; commitPruned: number; standardPruned: number }
+  | { kind: "skipped"; detail: string }
+  | { kind: "errored"; detail: string };
+
+/**
+ * One PruneRateLimits dispatch. Returns the outcome for tests /
+ * observability.
+ *
+ * `batchSize` caps the per-call work the contract does (default 100,
+ * hard-capped at 500 contract-side); we pass it through so operators
+ * can tune for chain-specific gas limits without redeploying.
+ */
+export async function runPruneIteration(
+  executor: Executor,
+  factoryAddress: string,
+  batchSize: number,
+): Promise<PruneOutcome> {
+  try {
+    const tx = await executor.execute(
+      factoryAddress,
+      factoryExecPruneRateLimits(batchSize),
+    );
+    // Extract the contract-emitted counters. The factory's handler
+    // always emits these two attributes, so missing values default to
+    // zero rather than failing the parse.
+    // tx.events is optional in the TxResult shape (some legacy
+    // CosmJS responses omit it); default to an empty array so the
+    // parse never blows up.
+    const { commitPruned, standardPruned } = parsePruneCounters(tx.events ?? []);
+    log.info("rate-limit prune complete", {
+      tx: tx.transactionHash,
+      commit_pruned: commitPruned,
+      standard_pruned: standardPruned,
+    });
+    return {
+      kind: "pruned",
+      txHash: tx.transactionHash,
+      commitPruned,
+      standardPruned,
+    };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    if (isExpectedSkipError(detail)) {
+      log.info("rate-limit prune skipped", { detail });
+      return { kind: "skipped", detail };
+    }
+    // Don't escalate — a failed prune doesn't break the protocol.
+    // Log and continue; next round will retry.
+    log.warn("rate-limit prune errored (non-fatal)", { detail });
+    return { kind: "errored", detail };
+  }
+}
+
+/** Internal: scrape `commit_pruned` and `standard_pruned` out of the tx events. */
+function parsePruneCounters(
+  events: ReadonlyArray<{ type: string; attributes: ReadonlyArray<{ key: string; value: string }> }>,
+): { commitPruned: number; standardPruned: number } {
+  let commitPruned = 0;
+  let standardPruned = 0;
+  for (const ev of events) {
+    // wasm event carries the contract-emitted attributes in CosmWasm 2.x.
+    if (ev.type !== "wasm") continue;
+    for (const attr of ev.attributes) {
+      if (attr.key === "commit_pruned") {
+        const n = Number.parseInt(attr.value, 10);
+        if (Number.isFinite(n)) commitPruned = n;
+      } else if (attr.key === "standard_pruned") {
+        const n = Number.parseInt(attr.value, 10);
+        if (Number.isFinite(n)) standardPruned = n;
+      }
+    }
+  }
+  return { commitPruned, standardPruned };
+}

--- a/keepers/src/lib/retry-notify-loop.ts
+++ b/keepers/src/lib/retry-notify-loop.ts
@@ -1,0 +1,170 @@
+// Retry-factory-notify keeper.
+//
+// Every commit pool, on threshold-cross, dispatches a NotifyThresholdCrossed
+// SubMsg to the factory using `reply_on_error`. If the factory rejects
+// (e.g., expand-economy reservoir is empty AND skip-with-Ok was configured
+// off, or some transient factory bug), the pool sets PENDING_FACTORY_NOTIFY
+// = true and the threshold-mint reward is held until somebody calls
+// pool.RetryFactoryNotify {}.
+//
+// The contract handler is permissionless on purpose — anyone can settle
+// the stuck mint. We add a keeper that polls each pool's
+// `FactoryNotifyStatus` query and dispatches RetryFactoryNotify only on
+// pools that report `pending = true`. Querying first avoids blasting
+// every pool every round (most pools have nothing pending most of the
+// time) so this loop is dirt-cheap on RPC.
+//
+// No bounty exists for this action — the contract doesn't pay one and
+// we don't need one (the keeper that runs this is the same operator
+// running the oracle/distribution keepers, who already absorbs the gas
+// cost of "running keepers" as part of running the protocol).
+//
+// Folded into the distribution-keeper process (rather than running as a
+// third long-lived bot) because:
+//   - It iterates the same POOL_ADDRESSES list.
+//   - Cadence (~ once per distribution sweep, every 30 min) is plenty:
+//     the failure mode it recovers from is rare and not time-sensitive,
+//     and 30-min-stale recovery is fine vs the operator-attention
+//     alternative of "wait for an alert and manually retry."
+
+import type { Executor } from "./executor.js";
+import {
+  PoolExecRetryFactoryNotify,
+  PoolQueryFactoryNotifyStatus,
+  isExpectedSkipError,
+  type FactoryNotifyStatusResponse,
+} from "./types.js";
+import { log } from "./logger.js";
+
+/** Per-pool outcome of one retry attempt. */
+export type RetryNotifyOutcome =
+  /** Query said `pending = false`; we did nothing. */
+  | { kind: "skipped"; pool: string; reason: "not_pending" }
+  /** Query said `pending = true`; tx succeeded. */
+  | { kind: "retried"; pool: string; txHash: string }
+  /**
+   * Tx errored with one of the expected skip markers (e.g., the pool
+   * reports "No pending factory notification to retry" because state
+   * changed between query and tx, or the factory reports
+   * "Bluechip mint already triggered" because the pending flag was
+   * stale). Treated as a clean no-op.
+   */
+  | { kind: "skipped"; pool: string; reason: "tx_skip"; detail: string }
+  /** Query failed (RPC issue, malformed response). Pool is left as-is. */
+  | { kind: "query_failed"; pool: string; detail: string }
+  /** Tx failed with an unexpected error. Operator action may be needed. */
+  | { kind: "errored"; pool: string; detail: string };
+
+/**
+ * Run the retry-notify check + dispatch for one pool.
+ *
+ * Two-phase: query first, only execute if the query says pending=true.
+ * This keeps the cost asymptotically O(N pools) queries per sweep
+ * rather than O(N) txs — the latter would cost real gas on every pool
+ * every round even when nothing needs doing.
+ */
+export async function checkAndRetryPool(
+  executor: Executor,
+  poolAddress: string,
+): Promise<RetryNotifyOutcome> {
+  let status: FactoryNotifyStatusResponse;
+  try {
+    status = await executor.queryContractSmart<FactoryNotifyStatusResponse>(
+      poolAddress,
+      PoolQueryFactoryNotifyStatus,
+    );
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    // Don't escalate query failures — a single pool's RPC blip
+    // shouldn't break the sweep. Log warn and move on.
+    log.warn("factory_notify_status query failed", { pool: poolAddress, detail });
+    return { kind: "query_failed", pool: poolAddress, detail };
+  }
+
+  if (!status.pending) {
+    return { kind: "skipped", pool: poolAddress, reason: "not_pending" };
+  }
+
+  log.info("pending factory notify detected; retrying", { pool: poolAddress });
+
+  try {
+    const tx = await executor.execute(poolAddress, PoolExecRetryFactoryNotify);
+    log.info("retry_factory_notify dispatched", {
+      pool: poolAddress,
+      tx: tx.transactionHash,
+    });
+    return { kind: "retried", pool: poolAddress, txHash: tx.transactionHash };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    if (isExpectedSkipError(detail)) {
+      log.info("retry_factory_notify skipped (state changed or already minted)", {
+        pool: poolAddress,
+        detail,
+      });
+      return { kind: "skipped", pool: poolAddress, reason: "tx_skip", detail };
+    }
+    log.error("retry_factory_notify errored", { pool: poolAddress, detail });
+    return { kind: "errored", pool: poolAddress, detail };
+  }
+}
+
+/**
+ * Aggregate result of a sweep across every configured pool.
+ * Exposed for observability + tests so callers can assert what
+ * happened without re-iterating the per-pool log lines.
+ */
+export interface RetryNotifySweepResult {
+  /** Per-pool outcomes in input order. */
+  outcomes: RetryNotifyOutcome[];
+  /** Convenience counters for at-a-glance dashboards. */
+  totals: {
+    retried: number;
+    skipped: number;
+    queryFailed: number;
+    errored: number;
+  };
+}
+
+/**
+ * One sweep across every configured pool. Outcomes are independent —
+ * a single pool's failure does not stop the sweep.
+ */
+export async function runRetryNotifySweep(
+  executor: Executor,
+  poolAddresses: ReadonlyArray<string>,
+): Promise<RetryNotifySweepResult> {
+  const outcomes: RetryNotifyOutcome[] = [];
+  const totals = { retried: 0, skipped: 0, queryFailed: 0, errored: 0 };
+
+  for (const pool of poolAddresses) {
+    const outcome = await checkAndRetryPool(executor, pool);
+    outcomes.push(outcome);
+    switch (outcome.kind) {
+      case "retried":
+        totals.retried += 1;
+        break;
+      case "skipped":
+        totals.skipped += 1;
+        break;
+      case "query_failed":
+        totals.queryFailed += 1;
+        break;
+      case "errored":
+        totals.errored += 1;
+        break;
+    }
+  }
+
+  if (totals.retried > 0 || totals.errored > 0) {
+    // Logger fields are flat (string | number | boolean), so flatten
+    // the totals struct rather than passing it as a nested object —
+    // keeps the per-line JSON aggregator-friendly.
+    log.info("retry-notify sweep complete", {
+      retried: totals.retried,
+      skipped: totals.skipped,
+      query_failed: totals.queryFailed,
+      errored: totals.errored,
+    });
+  }
+  return { outcomes, totals };
+}

--- a/keepers/src/lib/types.ts
+++ b/keepers/src/lib/types.ts
@@ -8,6 +8,41 @@
 
 export const FactoryExecUpdateOraclePrice = { update_oracle_price: {} } as const;
 export const PoolExecContinueDistribution = { continue_distribution: {} } as const;
+/**
+ * Pool-side recovery: re-sends NotifyThresholdCrossed to the factory when
+ * the original SubMsg landed in reply_on_error during the threshold-cross
+ * commit (e.g., expand-economy was stalled). Permissionless — anyone may
+ * call. Idempotent on the factory side via POOL_THRESHOLD_MINTED, so a
+ * stale/redundant call wastes the caller's gas but cannot double-mint.
+ */
+export const PoolExecRetryFactoryNotify = { retry_factory_notify: {} } as const;
+/**
+ * Factory-side storage hygiene (HIGH-2 audit follow-up). Iterates the
+ * per-address rate-limit maps and removes entries older than 10× the
+ * cooldown window. `batch_size` caps work per call (default 100, hard
+ * cap 500 on the contract side) so a large backlog doesn't exceed
+ * block gas limits in a single tx. Permissionless on the contract.
+ */
+export function factoryExecPruneRateLimits(batchSize: number) {
+  return { prune_rate_limits: { batch_size: batchSize } } as const;
+}
+
+// ---------------------------------------------------------------------------
+// Query messages — for read-only checks before deciding to send a tx
+// ---------------------------------------------------------------------------
+
+/**
+ * Pool query: returns `{ pending: bool }`. True when the pool's
+ * threshold cross succeeded but the factory-notify SubMsg landed on
+ * reply_on_error. We poll this from the retry keeper to decide
+ * whether RetryFactoryNotify is worth dispatching.
+ */
+export const PoolQueryFactoryNotifyStatus = { factory_notify_status: {} } as const;
+
+/** Wire-format mirror of `creator-pool::msg::FactoryNotifyStatusResponse`. */
+export interface FactoryNotifyStatusResponse {
+  pending: boolean;
+}
 
 // ---------------------------------------------------------------------------
 // Error sniffing — contract errors surface as strings in tx responses
@@ -26,6 +61,16 @@ const SKIP_MARKERS = [
   "too quickly",
   "NothingToRecover",
   "not found",
+  // RetryFactoryNotify: pool returns this when no notify is pending.
+  // Expected in normal operation — most pools don't have a pending
+  // notify most of the time — so treat as a clean skip rather than an
+  // error.
+  "No pending factory notification to retry",
+  // RetryFactoryNotify: factory rejects when POOL_THRESHOLD_MINTED is
+  // already true (idempotency gate). Means the previous mint actually
+  // landed and the pool's pending flag is just stale; the next round
+  // of activity will clear it.
+  "Bluechip mint already triggered",
 ] as const;
 
 export function isExpectedSkipError(message: string): boolean {

--- a/keepers/src/oracle-keeper.ts
+++ b/keepers/src/oracle-keeper.ts
@@ -7,6 +7,7 @@ import {
   checkKeeperBalance,
   runOracleIteration,
 } from "./lib/oracle-loop.js";
+import { runPruneIteration } from "./lib/prune-loop.js";
 import { interruptibleSleep } from "./lib/sleep.js";
 import { log } from "./lib/logger.js";
 
@@ -44,6 +45,22 @@ async function main(): Promise<void> {
     });
   }
 
+  // Iteration counter for the rate-limit prune sweep. We dispatch
+  // PruneRateLimits once every ORACLE_PRUNE_EVERY_N iterations of the
+  // oracle keeper. A counter (rather than wall-clock cadence) is used
+  // so the prune always runs immediately after a successful oracle
+  // iteration on the same wallet — keeping the sequence-number tx
+  // ordering simple. ORACLE_PRUNE_EVERY_N == 0 disables the sweep.
+  let pruneCounter = 0;
+  if (cfg.ORACLE_PRUNE_EVERY_N === 0) {
+    log.info("rate-limit prune sweep disabled (ORACLE_PRUNE_EVERY_N=0)");
+  } else {
+    log.info("rate-limit prune sweep enabled", {
+      every_n_iterations: cfg.ORACLE_PRUNE_EVERY_N,
+      batch_size: cfg.PRUNE_BATCH_SIZE,
+    });
+  }
+
   while (!stopped) {
     await runOracleIteration(client, cfg.FACTORY_ADDRESS, mockPush);
     await checkKeeperBalance(client, cfg.GAS_DENOM, cfg.MIN_KEEPER_BALANCE_UBLUECHIP);
@@ -53,6 +70,18 @@ async function main(): Promise<void> {
       cfg.GAS_DENOM,
       cfg.MIN_FACTORY_BOUNTY_RESERVE_UBLUECHIP,
     );
+
+    // Once every ORACLE_PRUNE_EVERY_N iterations, also run the
+    // rate-limit prune. Independent of the oracle iteration's success
+    // — a failed UpdateOraclePrice doesn't mean we shouldn't also
+    // prune; the two are unrelated chain operations.
+    if (cfg.ORACLE_PRUNE_EVERY_N > 0) {
+      pruneCounter += 1;
+      if (pruneCounter >= cfg.ORACLE_PRUNE_EVERY_N) {
+        pruneCounter = 0;
+        await runPruneIteration(client, cfg.FACTORY_ADDRESS, cfg.PRUNE_BATCH_SIZE);
+      }
+    }
 
     const ms = nextOracleSleepMs(cfg.ORACLE_POLL_INTERVAL_MS);
     log.info("sleeping", { ms });


### PR DESCRIPTION
Two new automated behaviors that close the recovery and storage-hygiene gaps surfaced by the audit, both tucked into existing keeper processes rather than spun up as separate bots.

Retry-factory-notify (in distribution-keeper):
- New lib/retry-notify-loop.ts: query-then-execute per pool. Polls pool.FactoryNotifyStatus first and only dispatches RetryFactoryNotify on pools that report pending=true, so the steady state is O(N) cheap queries instead of O(N) wasted-gas txs.
- Folded into the distribution-keeper sweep (runs before ContinueDistribution) because it iterates the same POOL_ADDRESSES at a similar cadence; recovery latency of ~30 min is fine — the failure mode this recovers from (factory-notify SubMsg landed in reply_on_error) is rare and not time-sensitive.
- Idempotent on the factory side via POOL_THRESHOLD_MINTED, so a redundant retry is at worst wasted gas, never a double-mint.

PruneRateLimits (in oracle-keeper):
- New lib/prune-loop.ts: dispatches the permissionless prune handler added in the previous audit-fix commit.
- Folded into the oracle-keeper as a once-per-N-iterations sweep (default ORACLE_PRUNE_EVERY_N=200, which at the 5.5min poll interval fires roughly daily). Set to 0 to disable entirely.
- Failed prune is logged at warn-level and never propagates — a stuck prune must not break the oracle main loop.

Plumbing:
- Extend Executor with queryContractSmart<T>() so loops can read contract state before deciding to send a tx. Wired through to CosmJS's existing queryContractSmart in client.ts.
- Extend mock-contracts.ts with FactoryNotifyStatus query, RetryFactoryNotify execute (with a forced-fail test hook for the idempotency-race path), and PruneRateLimits execute (with programmable counter responses).

Config:
- ORACLE_PRUNE_EVERY_N (default 200, allowZero) — disable by setting 0
- PRUNE_BATCH_SIZE (default 100) — passed through to PruneRateLimits

Tests: 10 new (6 retry-notify + 4 prune); full suite 78/78 pass; typecheck clean. README + .env.example updated with both new behaviors, new monitoring rows, and updated layout.

https://claude.ai/code/session_01EfSLnxrJEaBScFouKjwbb7