### PR TITLE
review fixes: doc cleanups, PendingBootstrapPrice atom_pool_price, tests

### DIFF
--- a/creator-pool/src/contract.rs
+++ b/creator-pool/src/contract.rs
@@ -217,10 +217,23 @@ fn check_pool_not_paused(storage: &dyn Storage) -> Result<(), ContractError> {
     Ok(())
 }
 
-/// Liquidity-write gate: hard-rejects when the pool is paused for any
-/// reason — admin pause, emergency-pending, or auto-pause due to low
-/// liquidity. Used for swaps, removes, fee collects, claims — i.e., paths
-/// that either drain reserves further or rely on healthy reserves.
+/// Strict liquidity gate: hard-rejects whenever the pool is paused
+/// for ANY reason — admin Pause, emergency-pending, or auto-pause due
+/// to low liquidity — and rejects when the pool is permanently
+/// drained.
+///
+/// Used by the creator-only claim paths (`ClaimCreatorExcessLiquidity`,
+/// `ClaimCreatorFees`). LP-mutating paths use the more permissive
+/// gates instead:
+///   - `check_pool_writable_for_remove` permits LP exits during the
+///     emergency-withdraw timelock window so LPs can race the drain.
+///   - `check_pool_writable_for_deposit` permits deposits during
+///     auto-pause so reserves can be restored.
+///
+/// Creator claims do not benefit from those relaxations: the creator
+/// excess + fee pot are admin-controlled fund flows, and the safer
+/// default during any non-None pause is to wait for the explicit
+/// resume signal (admin Unpause / emergency cancel).
 fn check_pool_writable(storage: &dyn Storage) -> Result<(), ContractError> {
     ensure_not_drained(storage)?;
     check_pool_not_paused(storage)

--- a/factory/src/execute.rs
+++ b/factory/src/execute.rs
@@ -186,13 +186,22 @@ pub fn execute(
 
 /// Permissionless storage hygiene (MEDIUM-2 audit fix). Iterates the
 /// per-address rate-limit maps and removes entries older than 10× the
-/// per-map cooldown window. Caller-supplied `batch_size` caps work
-/// per call (default 100, hard cap 500) so a large backlog doesn't
-/// exceed block gas limits in a single tx.
+/// per-map cooldown window.
 ///
-/// Without this, the rate-limit maps grow monotonically as new
-/// addresses interact and never shrink — a soft storage-bloat surface
-/// that compounds over the protocol's lifetime. Pruning is anybody's
+/// `batch_size` caps the number of entries REMOVED per call (default
+/// 100, hard cap 500). It does NOT cap the number iterated — each
+/// phase walks its map until either `batch_size` stale entries have
+/// been collected or the map ends. For realistic deployment scales
+/// this is fine: per-address 1h cooldowns mean the map can't grow
+/// faster than ~24 entries/day/active-address, and the keeper runs
+/// prune ~daily, so the map stays small enough that full iteration
+/// is well within block gas. If the map ever does balloon (extended
+/// prune outage, deliberate storage-bloat attack), operators tune
+/// the keeper to run more frequently AND can manually invoke this
+/// handler with larger `batch_size` to drain the backlog.
+///
+/// Without this handler, the rate-limit maps grow monotonically as
+/// new addresses interact and never shrink. Pruning is anybody's
 /// job: ops, keepers, or any community member can run it.
 fn execute_prune_rate_limits(
     deps: DepsMut,

--- a/factory/src/execute/pool_lifecycle/create.rs
+++ b/factory/src/execute/pool_lifecycle/create.rs
@@ -518,10 +518,8 @@ pub(crate) fn execute_create_standard_pool(
         ))));
     }
 
-    // Compute required fee. USD-denominated config converted to bluechip
-    // via the oracle; falls back to the hardcoded constant when the oracle
-    // is unavailable (the bootstrap case — the very first standard pool,
-    // typically the anchor itself, has no oracle data to draw on).
+    // Compute required fee. See the per-branch policy doc on the
+    // `match` below for the full fallback logic.
     let usd_fee = factory_config.standard_pool_creation_fee_usd;
     let (required_bluechip, fee_source) = if usd_fee.is_zero() {
         (Uint128::zero(), "disabled")

--- a/factory/src/internal_bluechip_price_oracle.rs
+++ b/factory/src/internal_bluechip_price_oracle.rs
@@ -952,17 +952,18 @@ pub fn update_internal_oracle_price(
         // Pop the just-pushed observation: branch (b) does the same
         // thing for symmetric reasons. Unconfirmed candidates must
         // not accumulate in the TWAP window.
-        let _ = current_time; // currently used only via env.block.time below
         oracle.bluechip_price_cache.twap_observations.pop();
 
         let pending = match crate::state::PENDING_BOOTSTRAP_PRICE.may_load(deps.storage)? {
             Some(prev) => crate::state::PendingBootstrapPrice {
                 price: twap_price,
+                atom_pool_price: atom_price,
                 proposed_at: prev.proposed_at,
                 observation_count: prev.observation_count.saturating_add(1),
             },
             None => crate::state::PendingBootstrapPrice {
                 price: twap_price,
+                atom_pool_price: atom_price,
                 proposed_at: env.block.time,
                 observation_count: 1,
             },
@@ -2061,14 +2062,18 @@ pub fn execute_confirm_bootstrap_price(
     oracle.bluechip_price_cache.last_price = pending.price;
     oracle.bluechip_price_cache.last_update = current_time;
     // Push the confirmed price as a real observation so the next
-    // round's TWAP window has prior data to compute against.
+    // round's TWAP window has prior data to compute against. The
+    // observation's `atom_pool_price` mirrors the value captured at
+    // the round that produced the candidate, NOT the candidate's own
+    // price (those are two different quantities — anchor-pool TWAP
+    // vs. cross-pool weighted bluechip-per-atom TWAP).
     oracle
         .bluechip_price_cache
         .twap_observations
         .push(PriceObservation {
             timestamp: current_time,
             price: pending.price,
-            atom_pool_price: pending.price,
+            atom_pool_price: pending.atom_pool_price,
         });
     // Cache the Pyth price too, mirroring the steady-state success tail.
     if let Ok(pyth_price) = query_pyth_atom_usd_price(deps.as_ref(), &env) {

--- a/factory/src/mint_bluechips_pool_creation.rs
+++ b/factory/src/mint_bluechips_pool_creation.rs
@@ -5,14 +5,23 @@ use crate::{
 use cosmwasm_std::{BankMsg, Coin, CosmosMsg, DepsMut, Env, StdError, StdResult, Uint128};
 
 /// Saturating cap on the mint-decay polynomial input (MEDIUM-4 audit
-/// fix). Realistic upper bound: per-address 1h create cooldown caps a
-/// single attacker at ~8.7k commit pools/year/address, so reaching 1B
-/// would need ~115k addresses operating continuously for 1000 years.
-/// Far above that, the polynomial output is structurally zero anyway
-/// (`(5x²+x) / (s/6 + 333x)` exceeds the 500e6 base around x ≈ 33e9
-/// for s == 0). Capping defensively avoids the theoretical u128
-/// overflow surface should a buggy migration or storage corruption
-/// ever inject an absurd ordinal directly.
+/// fix). Two concentric bounds are at play:
+///
+///   1. **Polynomial-is-zero bound (≈ 33,300):** `(5x²+x) / (s/6 + 333x)`
+///      crosses the 500e6 base around `x ≈ 33,300` at s == 0, so the
+///      polynomial output is structurally zero for any larger ordinal.
+///      Any cap above this is purely conservative.
+///
+///   2. **u128 overflow bound (≈ 8 × 10^18):** the inner `5 * x * x`
+///      overflows u128 around `x ≈ sqrt(2^128 / 5) ≈ 8 × 10^18`.
+///
+/// `MAX_DECAY_X = 1_000_000_000` sits comfortably between the two —
+/// well above any realistic ordinal an honest deployment will ever
+/// see, and well below the overflow ceiling. The cap exists purely
+/// as defense-in-depth against a buggy migration or storage
+/// corruption that injects an absurd ordinal directly into a
+/// `PoolDetails.commit_pool_ordinal`; under normal operation the
+/// per-address 1h create cooldown bounds the ordinal far below this.
 const MAX_DECAY_X: u128 = 1_000_000_000;
 
 pub fn calculate_mint_amount(seconds_elapsed: u64, pools_created: u64) -> StdResult<Uint128> {

--- a/factory/src/state.rs
+++ b/factory/src/state.rs
@@ -158,6 +158,13 @@ pub const PENDING_ORACLE_ROTATION: Item<Timestamp> = Item::new("pending_oracle_r
 #[cw_serde]
 pub struct PendingBootstrapPrice {
     pub price: Uint128,
+    /// ATOM-pool individual TWAP captured on the same round that
+    /// produced `price`. Carried through so `ConfirmBootstrapPrice`
+    /// can push a `PriceObservation` whose `atom_pool_price` field
+    /// matches the observation it's anchoring (rather than
+    /// duplicating `price` and misleading any downstream observability
+    /// query that reads the field).
+    pub atom_pool_price: Uint128,
     pub proposed_at: Timestamp,
     pub observation_count: u32,
 }

--- a/factory/src/testing/tests.rs
+++ b/factory/src/testing/tests.rs
@@ -4465,6 +4465,7 @@ mod validate_pool_token_info_tests {
 // math via successive UpdateOraclePrice executions.
 mod post_reset_buffer_tests {
     use super::*;
+    use crate::error::ContractError;
     use crate::internal_bluechip_price_oracle::{
         ANCHOR_CHANGE_WARMUP_OBSERVATIONS, MAX_POST_RESET_CONSECUTIVE_FAILURES,
     };
@@ -4924,5 +4925,215 @@ mod post_reset_buffer_tests {
             .expect("pending bootstrap price must be populated");
         assert!(!pending.price.is_zero(), "buffered candidate is non-zero");
         assert_eq!(pending.observation_count, 1);
+    }
+
+    /// HIGH-4 confirm path: after the 1h observation window elapses,
+    /// admin can publish the buffered candidate and warmup decrements.
+    #[test]
+    fn confirm_bootstrap_price_publishes_after_observation_window() {
+        let mut deps = mock_dependencies(&[]);
+        setup_factory_for_oracle_tests(&mut deps);
+        prime_post_reset_oracle(&mut deps, Uint128::zero());
+
+        // First update buffers a candidate.
+        let mut env = mock_env();
+        env.block.time = env.block.time.plus_seconds(360);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UpdateOraclePrice {},
+        )
+        .expect("buffered round");
+        let pending = crate::state::PENDING_BOOTSTRAP_PRICE
+            .load(&deps.storage)
+            .expect("buffered candidate populated");
+        let candidate_price = pending.price;
+
+        // Advance past the 1h observation window AND past the
+        // 5-minute UpdateOraclePrice cooldown.
+        let mut confirm_env = env.clone();
+        confirm_env.block.time = confirm_env
+            .block
+            .time
+            .plus_seconds(crate::state::BOOTSTRAP_OBSERVATION_SECONDS + 1);
+
+        let res = execute(
+            deps.as_mut(),
+            confirm_env,
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::ConfirmBootstrapPrice {},
+        )
+        .expect("confirm should succeed after observation window");
+
+        assert!(
+            res.attributes
+                .iter()
+                .any(|a| a.key == "action" && a.value == "confirm_bootstrap_price"),
+        );
+
+        let oracle = INTERNAL_ORACLE.load(&deps.storage).unwrap();
+        assert_eq!(
+            oracle.bluechip_price_cache.last_price, candidate_price,
+            "confirmed candidate must land in last_price"
+        );
+        assert_eq!(
+            oracle.warmup_remaining,
+            ANCHOR_CHANGE_WARMUP_OBSERVATIONS - 1,
+            "warmup decrements once on confirm"
+        );
+        assert!(
+            crate::state::PENDING_BOOTSTRAP_PRICE
+                .may_load(&deps.storage)
+                .unwrap()
+                .is_none(),
+            "pending candidate is cleared after confirm"
+        );
+    }
+
+    /// HIGH-4 timelock: confirm before the 1h observation window has
+    /// elapsed must reject. This is the main defense against an admin
+    /// (or compromised admin key) who tries to lock in a manipulated
+    /// first observation immediately.
+    #[test]
+    fn confirm_bootstrap_price_rejects_before_observation_window() {
+        let mut deps = mock_dependencies(&[]);
+        setup_factory_for_oracle_tests(&mut deps);
+        prime_post_reset_oracle(&mut deps, Uint128::zero());
+
+        let mut env = mock_env();
+        env.block.time = env.block.time.plus_seconds(360);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UpdateOraclePrice {},
+        )
+        .expect("buffered round");
+
+        // Try to confirm only 5 minutes later (well within the 1h window).
+        let mut early_env = env.clone();
+        early_env.block.time = early_env.block.time.plus_seconds(300);
+
+        let err = execute(
+            deps.as_mut(),
+            early_env,
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::ConfirmBootstrapPrice {},
+        )
+        .expect_err("confirm before observation window must error");
+
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("observation window"),
+            "expected observation-window error, got: {}",
+            msg
+        );
+
+        // last_price MUST still be zero — the buffered candidate has
+        // not been published.
+        let oracle = INTERNAL_ORACLE.load(&deps.storage).unwrap();
+        assert!(oracle.bluechip_price_cache.last_price.is_zero());
+    }
+
+    /// HIGH-4 auth: only the factory admin can confirm. A non-admin
+    /// caller — even one who's been watching the candidate stabilize
+    /// for hours — cannot publish it.
+    #[test]
+    fn confirm_bootstrap_price_rejects_non_admin() {
+        let mut deps = mock_dependencies(&[]);
+        setup_factory_for_oracle_tests(&mut deps);
+        prime_post_reset_oracle(&mut deps, Uint128::zero());
+
+        let mut env = mock_env();
+        env.block.time = env.block.time.plus_seconds(360);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UpdateOraclePrice {},
+        )
+        .expect("buffered round");
+
+        let mut later_env = env.clone();
+        later_env.block.time = later_env
+            .block
+            .time
+            .plus_seconds(crate::state::BOOTSTRAP_OBSERVATION_SECONDS + 1);
+
+        let err = execute(
+            deps.as_mut(),
+            later_env,
+            message_info(&Addr::unchecked("not_admin"), &[]),
+            ExecuteMsg::ConfirmBootstrapPrice {},
+        )
+        .expect_err("non-admin must be rejected");
+        assert!(matches!(err, ContractError::Unauthorized {}));
+    }
+
+    /// HIGH-4 cancel: admin can discard the candidate, forcing the
+    /// next round to start the observation window over from scratch.
+    #[test]
+    fn cancel_bootstrap_price_clears_pending_and_resets_window() {
+        let mut deps = mock_dependencies(&[]);
+        setup_factory_for_oracle_tests(&mut deps);
+        prime_post_reset_oracle(&mut deps, Uint128::zero());
+
+        let mut env = mock_env();
+        env.block.time = env.block.time.plus_seconds(360);
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UpdateOraclePrice {},
+        )
+        .expect("first buffered round");
+        let proposed_at_first = crate::state::PENDING_BOOTSTRAP_PRICE
+            .load(&deps.storage)
+            .unwrap()
+            .proposed_at;
+
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::CancelBootstrapPrice {},
+        )
+        .expect("admin can cancel");
+        assert!(
+            crate::state::PENDING_BOOTSTRAP_PRICE
+                .may_load(&deps.storage)
+                .unwrap()
+                .is_none(),
+            "cancel clears the pending candidate"
+        );
+
+        // After UPDATE_INTERVAL elapses, next update buffers a fresh
+        // candidate with a NEW proposed_at — confirming that the
+        // observation window restarts after cancel rather than
+        // carrying over from the discarded proposal.
+        //
+        // Drive the anchor pool's cumulative forward so the next
+        // `calculate_weighted_price_with_atom` round produces a real
+        // TWAP (rather than the snapshots-only no-op path that fires
+        // when there's no anchor activity between rounds).
+        advance_anchor_cumulative(&mut deps, 100, 1_000);
+        let mut next_env = env.clone();
+        next_env.block.time = next_env.block.time.plus_seconds(310);
+        execute(
+            deps.as_mut(),
+            next_env,
+            message_info(&admin_addr(), &[]),
+            ExecuteMsg::UpdateOraclePrice {},
+        )
+        .expect("second buffered round");
+        let proposed_at_second = crate::state::PENDING_BOOTSTRAP_PRICE
+            .load(&deps.storage)
+            .unwrap()
+            .proposed_at;
+        assert!(
+            proposed_at_second > proposed_at_first,
+            "cancel + re-buffer restarts the observation window"
+        );
     }
 }

--- a/keepers/src/__tests__/mock-contracts.ts
+++ b/keepers/src/__tests__/mock-contracts.ts
@@ -188,6 +188,17 @@ export class MockContracts implements Executor {
     this.failOnceAddresses.add(address);
   }
 
+  /**
+   * Test hook: the next queryContractSmart() against `address` throws
+   * with `error`. One-shot. Used to simulate transient RPC blips on
+   * the retry-notify keeper's pre-flight FactoryNotifyStatus query so
+   * we can assert it logs query_failed and never dispatches a tx.
+   */
+  private failOnceQueryAddresses = new Map<string, string>();
+  failNextQuery(address: string, error: string = "RPC: connection reset"): void {
+    this.failOnceQueryAddresses.set(address, error);
+  }
+
   // Executor impl --------------------------------------------------------
 
   async execute(contract: string, msg: Record<string, unknown>): Promise<TxResult> {
@@ -224,6 +235,11 @@ export class MockContracts implements Executor {
   }
 
   async queryContractSmart<T>(contract: string, msg: Record<string, unknown>): Promise<T> {
+    const failError = this.failOnceQueryAddresses.get(contract);
+    if (failError !== undefined) {
+      this.failOnceQueryAddresses.delete(contract);
+      throw new Error(failError);
+    }
     if ("factory_notify_status" in msg) {
       // Mirror creator-pool::query::query_factory_notify_status —
       // returns { pending: bool } reading from the pool's

--- a/keepers/src/__tests__/retry-notify-loop.test.ts
+++ b/keepers/src/__tests__/retry-notify-loop.test.ts
@@ -82,24 +82,16 @@ describe("retry-notify keeper", () => {
   });
 
   it("reports query_failed when the read errors and does not dispatch a tx", async () => {
-    // Override queryContractSmart on the mock to throw once.
-    const original = mock.queryContractSmart.bind(mock);
-    let calls = 0;
-    mock.queryContractSmart = async <T,>(
-      contract: string,
-      msg: Record<string, unknown>,
-    ): Promise<T> => {
-      calls += 1;
-      if (calls === 1) throw new Error("RPC: connection reset");
-      return original<T>(contract, msg);
-    };
+    mock.failNextQuery(POOL_A, "RPC: connection reset");
 
     const outcome = await checkAndRetryPool(mock, POOL_A);
     expect(outcome.kind).toBe("query_failed");
     if (outcome.kind === "query_failed") {
       expect(outcome.detail).toContain("RPC");
     }
-    // No execute call should have fired.
+    // No execute call should have fired — the keeper must never dispatch
+    // a tx on the back of a failed query (would waste gas on a pool
+    // whose pending state we don't actually know).
     const retryCalls = mock.calls.filter((c) => "retry_factory_notify" in c.msg);
     expect(retryCalls).toHaveLength(0);
   });


### PR DESCRIPTION
Self-review pass over the audit + keeper changes turned up several issues, all addressed here. No behavior change to keeper bots; the only on-chain semantic change is `PendingBootstrapPrice` carrying `atom_pool_price` through to ConfirmBootstrapPrice's emitted PriceObservation.

Doc / comment cleanups (no behavior change):
- creator-pool::check_pool_writable doc was stale after the HIGH-1 wiring (claimed it gated swaps/removes/collects when in fact it only gates the two ClaimCreator* paths now). Rewrote the docstring to match the dispatch wiring.
- factory::execute_create_standard_pool fee-fallback intro comment was stale after the HIGH-3 cap; replaced with a pointer to the per-branch policy doc on the match expression.
- factory::execute_prune_rate_limits comment overpromised ("batch_size caps work per call so large maps don't exceed gas"). Rewrote to reflect what the code actually does (caps removes per call, NOT iteration; safe for realistic deployment scales because the keeper prunes daily and entries can't grow faster than that).
- factory::calculate_mint_amount comment had broken math for the reachability bound. Rewrote with the actual two-bound rationale (polynomial-is-zero ≈ 33,300 vs u128-overflow ≈ 8e18) and the defense-in-depth motivation for `MAX_DECAY_X = 1e9`.
- Removed a leftover `let _ = current_time;` no-op suppression in the oracle's branch (d).

PendingBootstrapPrice carries atom_pool_price (cosmetic correctness):
- Branch (d)'s buffered candidate is published by ConfirmBootstrapPrice as a PriceObservation. The previous code set the observation's `atom_pool_price` field equal to `pending.price`, conflating the cross-pool weighted bluechip-per-atom TWAP with the anchor pool's individual TWAP — two different quantities. The field is observability data only (no TWAP math reads it), so this never affected pricing, but it would confuse any indexer / dashboard reading observations. Added `atom_pool_price` to PendingBootstrapPrice; branch (d) captures it alongside `price`; ConfirmBootstrapPrice publishes the observation with the right value.

Test cleanups:
- Replaced an ad-hoc method-monkey-patch in retry-notify-loop.test.ts (`mock.queryContractSmart = ...`) with a proper `failNextQuery()` test hook on MockContracts. Cleaner, self-documenting, mirrors the existing `failNextExecute` pattern.

New factory-side tests for HIGH-4 confirm/cancel flow:
- confirm_bootstrap_price_publishes_after_observation_window
- confirm_bootstrap_price_rejects_before_observation_window
- confirm_bootstrap_price_rejects_non_admin
- cancel_bootstrap_price_clears_pending_and_resets_window

cargo test --lib -p factory: 156 passing (was 152 pre-review), same 9 pre-existing failures from before the audit work — zero new regressions. cargo check --all and npm run typecheck: clean.
keeper test suite: 78/78 pass.

https://claude.ai/code/session_01EfSLnxrJEaBScFouKjwbb7