### PR TITLE
Fuzz: add review doc, strengthen invariants, add oracle staleness, and adjust fuzz.sh quick-mode

### DIFF
--- a/FUZZ_REVIEW.md
+++ b/FUZZ_REVIEW.md
@@ -1,0 +1,137 @@
+# Fuzzing Review (Phase 1 + Phase 2) and Gap Analysis
+
+## Scope reviewed
+- `fuzz.sh`, `FUZZING.md`, `fuzz-stateful/*`, `fuzz/fuzz_targets/*`.
+- Workspace and per-crate `Cargo.toml` files.
+- Contract msg/state surfaces for `factory`, `creator-pool`, `standard-pool`, `expand-economy`, `router`, `mockoracle`.
+
+---
+
+## Phase 1: protocol orientation summary
+
+### Entry points by contract
+- **factory**
+  - Instantiate: `instantiate`
+  - Execute highlights: config propose/apply/cancel, creator pool creation, standard pool creation, oracle update/rotation, pool pause/unpause/emergency/recovery forwards, threshold notification, upgrade flows, anchor-pool bootstrap, bounty controls. (`factory/src/msg.rs`)
+  - Query highlights: factory snapshot, creator token info, oracle conversion/internal oracle query, bounties, pool creation status. (`factory/src/query.rs`)
+- **creator-pool**
+  - Instantiate: pool init with commit threshold + payout config.
+  - Execute highlights: commit, swaps (native + cw20 hook), deposit/remove liquidity, fee collection, distribution progression, pause/unpause/emergency lifecycle, creator claims, retry factory threshold notify. (`creator-pool/src/msg.rs`)
+  - Query highlights: pair/config/simulations, fee state, threshold status, committer state, positions, analytics, distribution state, paused state. (`creator-pool/src/msg.rs`)
+- **standard-pool**
+  - Instantiate: standard XYK pool.
+  - Execute highlights: swaps, deposit/remove liquidity, fee collection, pause/unpause/emergency lifecycle, factory config updates.
+  - Query highlights: pair/config/simulation/reverse simulation, fee state, positions, pool info/state, paused state. (`standard-pool/src/msg.rs`)
+- **expand-economy**
+  - Instantiate: owner/factory + denom config.
+  - Execute highlights: expansion request, config propose/apply/cancel, withdrawal propose/execute/cancel. (`expand-economy/src/msg.rs`)
+  - Query highlights: config, balance by denom. (`expand-economy/src/msg.rs`)
+- **router**
+  - Instantiate: factory/admin/denom.
+  - Execute highlights: multihop, cw20 receive, internal hop execution, assert-received, config propose/apply/cancel. (`router/src/msg.rs`)
+  - Query highlights: simulate multihop, config. (`router/src/msg.rs`)
+- **mockoracle**
+  - Instantiate: empty.
+  - Execute: set price.
+  - Query: get price, conversion feed response. (`mockoracle/src/msg.rs`)
+
+### Storage items (name -> key type)
+- **factory**
+  - `FACTORYINSTANTIATEINFO` -> `Item<FactoryInstantiate>`
+  - `POOL_CREATION_CONTEXT` -> `Map<u64, PoolCreationContext>`
+  - `POOL_COUNTER`, `COMMIT_POOL_COUNTER` -> `Item<u64>`
+  - `POOLS_BY_ID` -> `Map<u64, PoolDetails>`
+  - `POOLS_BY_CONTRACT_ADDRESS` -> `Map<Addr, PoolStateResponseForFactory>`
+  - `POOL_THRESHOLD_MINTED` -> `Map<u64, bool>`
+  - plus pending config/upgrade/oracle/bootstrap/rate-limit/bounty maps/items. (`factory/src/state.rs`)
+- **creator-pool**
+  - Commit-specific: `USD_RAISED_FROM_COMMIT`, `NATIVE_RAISED_FROM_COMMIT`, `THRESHOLD_PROCESSING`, `PENDING_FACTORY_NOTIFY`, `DISTRIBUTION_STATE`, `LAST_THRESHOLD_ATTEMPT`, `CREATOR_EXCESS_POSITION`, `COMMIT_LIMIT_INFO`.
+  - Per-user maps: `COMMIT_INFO: Map<&Addr, Committing>`, `COMMIT_LEDGER: Map<&Addr, Uint128>`, `LAST_CONTINUE_DISTRIBUTION_AT: Map<&Addr, u64>`.
+  - Also inherits shared `pool_core::state::*` items (reserves, positions, config, fees, etc.). (`creator-pool/src/state.rs`, `packages/pool-core/src/state.rs`)
+- **standard-pool**
+  - Uses shared `pool_core::state` items (reserves, positions, config/fees, pause/emergency markers).
+- **expand-economy**
+  - `CONFIG: Item<Config>`
+  - `EXPANSION_WINDOW: Item<ExpansionWindow>`
+  - `LAST_EXPANSION_AT_RECIPIENT: Map<&str, Timestamp>`
+  - `PENDING_WITHDRAWAL`, `PENDING_CONFIG_UPDATE` as `Item<...>`. (`expand-economy/src/state.rs`)
+- **router**
+  - `CONFIG: Item<Config>`
+  - `PENDING_CONFIG: Item<PendingConfigUpdate>`. (`router/src/state.rs`)
+- **mockoracle**
+  - `PRICES: Map<&str, PriceResponse>`. (`mockoracle/src/oracle_contract.rs`)
+
+### Cross-contract call graph (main paths)
+- factory -> creator-pool/standard-pool instantiate on pool creation.
+- creator-pool -> factory `NotifyThresholdCrossed` / bounty pathways.
+- factory -> expand-economy `RequestExpansion`.
+- factory -> pools for admin forwards (`Pause`, `Unpause`, `EmergencyWithdraw`, recovery, config update).
+- factory -> Pyth/mockoracle query for price conversion.
+- router -> pool swap execute/query and factory query for route validation.
+- pool -> cw20 token contracts (`Send`, `Transfer`, allowances).
+
+### Numeric types used in arithmetic
+- Widespread: `Uint128`, `u64`, `u32`, `u16`, `Decimal`, timestamps (`u64` seconds), and i64/i32-style oracle fields in mock/Pyth compatibility surfaces.
+- Fuzz math targets additionally parse `u128` tuples and vectorized `u128` commitments.
+
+---
+
+## Phase 2: invariant inventory (recommended 22)
+
+> Signature pattern requested:
+`fn check_invariant_NAME(app: &App, ...) -> Result<(), String>`
+
+### A) Conservation
+1. `fn check_invariant_pool_native_reserve_backed(app: &App, pool: Addr) -> Result<(), String>`
+2. `fn check_invariant_pool_cw20_reserve_backed(app: &App, pool: Addr, token: Addr) -> Result<(), String>`
+3. `fn check_invariant_total_liquidity_ge_sum_positions(app: &App, pool: Addr) -> Result<(), String>`
+4. `fn check_invariant_commit_ledger_sum_le_total_committed_usd(app: &App, pool: Addr) -> Result<(), String>`
+5. `fn check_invariant_creator_fee_pot_nonnegative_and_claimable(app: &App, pool: Addr) -> Result<(), String>`
+
+### B) Monotonicity
+6. `fn check_invariant_threshold_sticky_once_hit(app: &App, pool: Addr) -> Result<(), String>`
+7. `fn check_invariant_usd_raised_non_decreasing_pre_threshold(app: &App, pool: Addr) -> Result<(), String>`
+8. `fn check_invariant_pool_threshold_minted_flag_non_reverting(app: &App, pool_id: u64) -> Result<(), String>`
+9. `fn check_invariant_distribution_progress_monotone(app: &App, pool: Addr) -> Result<(), String>`
+10. `fn check_invariant_expand_economy_window_spent_monotone_within_window(app: &App) -> Result<(), String>`
+
+### C) Authorization
+11. `fn check_invariant_only_factory_can_pause_unpause_emergency(app: &App, pool: Addr) -> Result<(), String>`
+12. `fn check_invariant_only_factory_can_update_pool_config(app: &App, pool: Addr) -> Result<(), String>`
+13. `fn check_invariant_only_creator_can_claim_creator_fees(app: &App, pool: Addr) -> Result<(), String>`
+14. `fn check_invariant_only_admin_can_factory_timelock_actions(app: &App) -> Result<(), String>`
+15. `fn check_invariant_only_admin_can_router_config_changes(app: &App) -> Result<(), String>`
+
+### D) Arithmetic safety
+16. `fn check_invariant_swap_simulation_no_overflow_for_live_state(app: &App, pool: Addr) -> Result<(), String>`
+17. `fn check_invariant_threshold_usd_conversion_matches_reference(app: &App, pool: Addr) -> Result<(), String>`
+18. `fn check_invariant_expand_formula_output_within_bounds(app: &App, supply: u128, x: u128) -> Result<(), String>`
+19. `fn check_invariant_fee_bps_and_spread_bounds(app: &App, pool: Addr) -> Result<(), String>`
+
+### E) Phase exclusivity
+20. `fn check_invariant_no_swap_before_commit_threshold_in_creator_pool(app: &App, pool: Addr) -> Result<(), String>`
+21. `fn check_invariant_no_commit_after_threshold_cross(app: &App, pool: Addr) -> Result<(), String>`
+22. `fn check_invariant_emergency_drained_pool_rejects_state_changes(app: &App, pool: Addr) -> Result<(), String>`
+
+---
+
+## Review of current fuzz setup vs contract behavior
+
+### What is already good
+- `fuzz.sh` runs both quick and full stateful proptest and pure-math mirrors; supports long mode with cargo-fuzz targets. (`fuzz.sh`)
+- Stateful harness includes legal + intentionally-illegal actions (unauthorized config, fake threshold notify, zero oracle, emergency misuse). (`fuzz-stateful/src/actions.rs`)
+- Invariants already check reserve backing, threshold stickiness, liquidity over-claim prevention, and drained-pool operation rejection. (`fuzz-stateful/src/invariants.rs`)
+- Three cargo-fuzz targets exist and are wired in `fuzz/Cargo.toml`. (`fuzz/fuzz_targets/*.rs`, `fuzz/Cargo.toml`)
+
+### Potential gaps
+1. **`fuzz.sh` quick-mode still runs both quick+full stateful passes** (quick is not really ~30s by default on slower CI hosts).
+2. **No explicit invariant for “commit forbidden post-threshold”** (relies on action rejection but not asserted globally each step).
+3. **No invariant binding factory `POOL_THRESHOLD_MINTED` to exactly-once economics** (only sticky flag check, not amount/cap correctness).
+4. **No cross-check that oracle staleness/zero/negative branches reject exactly where intended** for all relevant entrypoints.
+5. **No explicit invariant for timelock correctness** (factory/router/expand-economy propose/apply/cancel temporal constraints).
+6. **No invariant for expand-economy rolling cap + recipient rate-limit conservation** during repeated notify/retry storms.
+7. **No strict constant-product tolerance invariant over executed swaps** (math target checks formula, stateful harness should bind live reserve transitions too).
+8. **Action space misses explicit “stale oracle > max age” action toggle** (only rate mutation value variants are present).
+9. **No invariant asserting distribution completion drains `COMMIT_LEDGER` as expected**.
+10. **No direct property on NFT position ownership integrity during add/remove/claim sequences**.
+

--- a/fuzz-stateful/src/actions.rs
+++ b/fuzz-stateful/src/actions.rs
@@ -82,6 +82,8 @@ pub enum Action {
     UpdateOraclePrice {
         #[proptest(strategy = "::proptest::sample::select(vec![0u128, 1u128, 1_000u128, 1_000_000u128, 5_000_000u128, 1_000_000_000_000u128])")]
         new_rate: u128,
+        #[proptest(strategy = "::proptest::sample::select(vec![0u64, 30u64, 120u64, 3600u64])")]
+        stale_secs: u64,
     },
     /// Skip forward in time + block height.
     AdvanceBlock {
@@ -406,8 +408,10 @@ pub fn apply(world: &mut World, action: Action) -> ActionOutcome {
                 Err(e) => mk_rejected(action_dbg, &format!("remove: {e}")),
             }
         }
-        Action::UpdateOraclePrice { new_rate } => {
-            let res = set_oracle_rate(world, Uint128::new(new_rate));
+        Action::UpdateOraclePrice { new_rate, stale_secs } => {
+            let now = world.app.block_info().time.seconds();
+            let ts = now.saturating_sub(stale_secs);
+            let res = set_oracle_rate(world, Uint128::new(new_rate), ts);
             match (new_rate, res) {
                 (0, Err(_)) => mk_expected(action_dbg, "rate=0 rejected"),
                 (0, Ok(_)) => panic!("INVARIANT BROKEN: shim accepted rate=0"),

--- a/fuzz-stateful/src/invariants.rs
+++ b/fuzz-stateful/src/invariants.rs
@@ -15,9 +15,26 @@ pub struct Violation {
 }
 
 pub fn check_all(world: &mut World) -> Result<(), Violation> {
+    check_threshold_mint_count(world)?;
     for i in 0..world.pools.len() {
         let pool_snapshot = world.pools[i].clone();
         check_pool_invariants(world, i, &pool_snapshot)?;
+    }
+    Ok(())
+}
+
+fn check_threshold_mint_count(world: &mut World) -> Result<(), Violation> {
+    let notify_count: u64 = world
+        .app
+        .wrap()
+        .query_wasm_smart(&world.factory_shim, &HarnessQueryMsg::NotifyCount {})
+        .map_err(|e| violation("notify_count_query_failed", format!("{e:?}")))?;
+    let threshold_hit_pools = world.pools.iter().filter(|p| p.threshold_hit_seen).count() as u64;
+    if notify_count > threshold_hit_pools {
+        return Err(violation(
+            "threshold_mint_notify_exceeded_threshold_hits",
+            format!("notify_count={} > threshold_hit_pools={}", notify_count, threshold_hit_pools),
+        ));
     }
     Ok(())
 }
@@ -109,6 +126,32 @@ fn check_pool_invariants(world: &mut World, i: usize, snap: &crate::world::PoolH
         }
         if now_hit { world.pools[i].threshold_hit_seen = true; }
 
+        // Phase exclusivity: once threshold is hit, Commit must reject.
+        if now_hit {
+            let probe = world.app.execute_contract(
+                world.users[0].clone(),
+                pool_addr.clone(),
+                &creator_pool::msg::ExecuteMsg::Commit {
+                    asset: pool_factory_interfaces::asset::TokenInfo {
+                        info: pool_factory_interfaces::asset::TokenType::Native {
+                            denom: BLUECHIP_DENOM.to_string(),
+                        },
+                        amount: Uint128::new(1),
+                    },
+                    transaction_deadline: None,
+                    belief_price: None,
+                    max_spread: None,
+                },
+                &[Coin::new(1u128, BLUECHIP_DENOM)],
+            );
+            if probe.is_ok() {
+                return Err(violation(
+                    "commit_allowed_post_threshold",
+                    format!("pool {} accepted Commit after FullyCommitted", pool_addr),
+                ));
+            }
+        }
+
         // Factory shim should record minted exactly when threshold notified.
         let minted: bool = world
             .app
@@ -162,6 +205,34 @@ fn check_pool_invariants(world: &mut World, i: usize, snap: &crate::world::PoolH
                 pool_addr, sum_pos_liquidity, pool_state.total_liquidity, total_positions
             ),
         ));
+    }
+
+    // Position/NFT integrity: for queried positions, cw721 owner must match
+    // recorded position owner.
+    let owner_page: PositionsResponse = world
+        .app
+        .wrap()
+        .query_wasm_smart(
+            pool_addr,
+            &creator_pool::msg::QueryMsg::Positions { start_after: None, limit: Some(5) },
+        )
+        .map_err(|e| violation("positions_integrity_query_failed", format!("{e:?}")))?;
+    for p in owner_page.positions {
+        let q = pool_factory_interfaces::cw721_msgs::Cw721QueryMsg::OwnerOf {
+            token_id: p.position_id.clone(),
+            include_expired: None,
+        };
+        let owner: pool_factory_interfaces::cw721_msgs::OwnerOfResponse = world
+            .app
+            .wrap()
+            .query_wasm_smart(&snap.nft_addr, &q)
+            .map_err(|e| violation("nft_owner_query_failed", format!("{e:?}")))?;
+        if owner.owner != p.owner {
+            return Err(violation(
+                "position_nft_owner_mismatch",
+                format!("position {} owner {} != nft owner {}", p.position_id, p.owner, owner.owner),
+            ));
+        }
     }
 
     // -- Drained pool blocks ops: once we observed a successful drain,

--- a/fuzz-stateful/src/world.rs
+++ b/fuzz-stateful/src/world.rs
@@ -733,7 +733,7 @@ fn short_ticker(prefix: &str, pool_id: u64) -> String {
     s
 }
 
-pub fn set_oracle_rate(world: &mut World, new_rate: Uint128) -> Result<(), String> {
+pub fn set_oracle_rate(world: &mut World, new_rate: Uint128, timestamp: u64) -> Result<(), String> {
     world
         .app
         .execute_contract(
@@ -741,7 +741,7 @@ pub fn set_oracle_rate(world: &mut World, new_rate: Uint128) -> Result<(), Strin
             world.factory_shim.clone(),
             &factory_shim::HarnessExecuteMsg::SetRate {
                 new_rate,
-                timestamp: 0,
+                timestamp,
             },
             &[],
         )

--- a/fuzz.sh
+++ b/fuzz.sh
@@ -27,12 +27,17 @@ echo "==> [1/3] Stateful proptest harness ($PROPTEST_QUICK_CASES quick cases)"
 PROPTEST_CASES="$PROPTEST_QUICK_CASES" cargo test \
   -p fuzz-stateful --release --test fuzz_stateful fuzz_stateful_quick
 
-echo "==> [2/3] Stateful proptest harness ($PROPTEST_FULL_CASES full cases)"
-PROPTEST_CASES="$PROPTEST_FULL_CASES" cargo test \
-  -p fuzz-stateful --release --test fuzz_stateful fuzz_stateful
+if [ "$MODE" = "quick" ]; then
+  echo "==> [2/2] Pure-math proptests (stable mirror of cargo-fuzz targets)"
+  cargo test -p fuzz-stateful --release --test proptest_pure_math
+else
+  echo "==> [2/3] Stateful proptest harness ($PROPTEST_FULL_CASES full cases)"
+  PROPTEST_CASES="$PROPTEST_FULL_CASES" cargo test \
+    -p fuzz-stateful --release --test fuzz_stateful fuzz_stateful
 
-echo "==> [3/3] Pure-math proptests (stable mirror of cargo-fuzz targets)"
-cargo test -p fuzz-stateful --release --test proptest_pure_math
+  echo "==> [3/3] Pure-math proptests (stable mirror of cargo-fuzz targets)"
+  cargo test -p fuzz-stateful --release --test proptest_pure_math
+fi
 
 if [ "$MODE" = "long" ]; then
   if ! command -v cargo-fuzz >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation
- Document the current fuzzing setup, contract surfaces, and a phase-2 invariant inventory to guide further fuzzing work by adding `FUZZ_REVIEW.md`.
- Improve stateful fuzz harness fidelity by exercising oracle staleness cases and threading timestamps into oracle updates.
- Strengthen invariant coverage to catch cross-contract and phase-exclusivity regressions (threshold mint accounting, post-threshold commits, NFT ownership integrity). 

### Description
- Add `FUZZ_REVIEW.md` with protocol orientation, storage summaries, cross-contract graph, recommended invariants, and a gap analysis. 
- Extend the `UpdateOraclePrice` action in `fuzz-stateful/src/actions.rs` to include a `stale_secs` parameter and pass a computed timestamp to the oracle shim. 
- Change `set_oracle_rate` signature in `fuzz-stateful/src/world.rs` to accept a `timestamp` and forward it to the factory shim. 
- Add `check_threshold_mint_count` to `fuzz-stateful/src/invariants.rs` to assert the factory's notify count does not exceed observed threshold hits, and add a probe that ensures `Commit` is rejected once a creator-pool reaches `FullyCommitted`. 
- Add position/NFT ownership integrity checks in `fuzz-stateful/src/invariants.rs` to ensure the cw721 `OwnerOf` matches reported position owners. 
- Update `fuzz.sh` to make `quick` mode skip the long stateful run and instead run the stable pure-math proptests, while preserving the full workflow when not in `quick` mode. 

### Testing
- Ran the quick fuzz workflow via `./fuzz.sh` (quick) which executes the stateful quick harness and the pure-math proptests; all checks completed successfully. 
- Ran stateful and pure-math proptests directly (`cargo test -p fuzz-stateful --release --test fuzz_stateful fuzz_stateful_quick` and `cargo test -p fuzz-stateful --release --test proptest_pure_math`); both suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f4d55b18832a95c01cb4a3454a3f)