### PR TITLE
expand-economy: pay down audit-flagged technical debt

### DIFF
--- a/expand-economy/src/attrs.rs
+++ b/expand-economy/src/attrs.rs
@@ -1,0 +1,58 @@
+//! Centralized attribute key + action-value constants.
+//!
+//! Every `Response::add_attribute` site in this crate references one of
+//! these constants rather than a string literal. Off-chain indexers can
+//! pin against the constants directly, and a typo in any single emission
+//! becomes a compile error rather than a silent wire-format drift.
+
+// ---- Attribute keys ------------------------------------------------------
+
+pub const ACTION: &str = "action";
+pub const RECIPIENT: &str = "recipient";
+pub const AMOUNT: &str = "amount";
+pub const DENOM: &str = "denom";
+pub const FACTORY: &str = "factory";
+pub const OWNER: &str = "owner";
+pub const BLUECHIP_DENOM: &str = "bluechip_denom";
+pub const REASON: &str = "reason";
+pub const NOTE: &str = "note";
+pub const VARIANT: &str = "variant";
+pub const REQUESTED_AMOUNT: &str = "requested_amount";
+pub const CONTRACT_BALANCE: &str = "contract_balance";
+pub const SPENT_IN_WINDOW_AFTER: &str = "spent_in_window_after";
+pub const DAILY_CAP: &str = "daily_cap";
+/// Timelock unlock time, attached to every propose / execute response on
+/// both the config and withdrawal flows. Single key — both timelock
+/// kinds emit the same name so off-chain indexers can use one parser.
+pub const UNLOCKS_AT: &str = "unlocks_at";
+pub const CONTRACT_NAME: &str = "contract_name";
+pub const CONTRACT_VERSION: &str = "contract_version";
+
+// ---- Action values -------------------------------------------------------
+
+pub const INSTANTIATE: &str = "instantiate";
+pub const REQUEST_REWARD: &str = "request_reward";
+pub const REQUEST_REWARD_SKIPPED: &str = "request_reward_skipped";
+pub const PROPOSE_CONFIG_UPDATE: &str = "propose_config_update";
+pub const EXECUTE_CONFIG_UPDATE: &str = "execute_config_update";
+pub const CANCEL_CONFIG_UPDATE: &str = "cancel_config_update";
+pub const PROPOSE_WITHDRAWAL: &str = "propose_withdrawal";
+pub const EXECUTE_WITHDRAWAL: &str = "execute_withdrawal";
+pub const CANCEL_WITHDRAWAL: &str = "cancel_withdrawal";
+pub const MIGRATE: &str = "migrate";
+
+// ---- Reason values (for `request_reward_skipped`) -----------------------
+
+pub const REASON_ECONOMY_DORMANT: &str = "economy_dormant";
+pub const REASON_INSUFFICIENT_BALANCE: &str = "insufficient_balance";
+
+// ---- Note values ---------------------------------------------------------
+
+pub const NOTE_ECONOMY_DORMANT: &str =
+    "ExpandEconomy mint schedule has reached zero; no further expansions \
+     will be dispensed. This is the intended end-state of the decay curve.";
+pub const NOTE_WITHDRAWAL_NO_FUNDS: &str = "no funds available; withdrawal skipped";
+
+// ---- Migrate variant values ---------------------------------------------
+
+pub const MIGRATE_VARIANT_UPDATE_VERSION: &str = "update_version";

--- a/expand-economy/src/contract.rs
+++ b/expand-economy/src/contract.rs
@@ -1,161 +1,34 @@
+//! CosmWasm entry points + dispatcher. The bulk of the handler logic
+//! lives in topic-aligned submodules:
+//!
+//!   - [`crate::expand`]        — the `RequestExpansion` flow, decomposed
+//!                                into one helper per phase.
+//!   - [`crate::timelock`]      — propose / apply / cancel for both
+//!                                config and withdrawal (48h timelock).
+//!   - [`crate::migrate`]       — migrate handler + downgrade guard.
+//!   - [`crate::denom`]         — cosmos-sdk denom format validator.
+//!   - [`crate::factory_query`] — wire types + cross-validation helper.
+//!   - [`crate::helpers`]       — shared owner-gating + storage helpers.
+//!   - [`crate::attrs`]         — every attribute key / action value.
+
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_json_binary, Addr, BankMsg, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, StdResult, Storage, Uint128,
+    to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError,
 };
 use cw2::set_contract_version;
-use cw_storage_plus::Item;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
+use crate::attrs;
+use crate::denom::validate_native_denom;
 use crate::error::ContractError;
-use crate::msg::{ConfigResponse, ExecuteMsg, ExpandEconomyMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use crate::state::{
-    Config, ExpansionWindow, PendingConfigUpdate, PendingWithdrawal, CONFIG,
-    CONFIG_TIMELOCK_SECONDS, DAILY_EXPANSION_CAP, DAILY_WINDOW_SECONDS, DEFAULT_BLUECHIP_DENOM,
-    EXPANSION_WINDOW, LAST_EXPANSION_AT_RECIPIENT, PENDING_CONFIG_UPDATE, PENDING_WITHDRAWAL,
-    RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS, WITHDRAW_TIMELOCK_SECONDS,
+use crate::expand::execute_expand_economy;
+use crate::msg::{ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::state::{Config, CONFIG, DEFAULT_BLUECHIP_DENOM};
+use crate::timelock::{
+    execute_apply_config_update, execute_cancel_config_update, execute_cancel_withdrawal,
+    execute_propose_config_update, execute_propose_withdrawal, execute_withdrawal,
 };
-
-/// Minimal subset of the factory's query interface that this contract
-/// uses to cross-validate `bluechip_denom`. Defined locally to avoid a
-/// compile-time dependency on the `factory` crate (the two communicate
-/// only over wasm message boundaries).
-///
-/// Deliberately uses plain `#[derive(serde::Serialize)]` +
-/// explicit `rename_all = "snake_case"` rather than `#[cw_serde]`. The
-/// query message we send to the factory must match
-/// `factory::query::QueryMsg::Factory {}` on the wire — `cw_serde`
-/// adds `rename_all = "snake_case"` for enums via macro magic, which
-/// works today but couples our wire format to a tooling
-/// implementation detail. Using plain serde derives makes the wire
-/// contract explicit and resilient to future cosmwasm-schema changes.
-#[derive(Serialize)]
-#[serde(rename_all = "snake_case")]
-enum FactoryQuery {
-    Factory {},
-}
-
-/// Wire-compatible subset of `factory::msg::FactoryInstantiateResponse`
-/// — only the field this contract reads.
-///
-/// Uses plain `#[derive(serde::Deserialize)]` rather than `#[cw_serde]`.
-/// `cw_serde` is documented in cosmwasm-schema 2.x today as NOT setting
-/// `deny_unknown_fields`, but that's a tooling default that could
-/// reasonably flip in a future release — and if it ever does, every
-/// `RequestExpansion` would fail with an opaque "unknown field"
-/// deserialization error inside `query_wasm_smart`, silently bricking
-/// every threshold-crossing bluechip mint.
-///
-/// Plain `#[derive(serde::Deserialize)]` does NOT add
-/// `deny_unknown_fields`, so the "extra factory-side fields are
-/// ignored" property is locked in by serde's documented default
-/// behavior rather than a transitive cosmwasm-schema choice. Combined
-/// with the round-trip test in `tests::factory_response_round_trip`,
-/// this future-proofs the cross-validation path.
-#[derive(Deserialize)]
-struct FactoryConfigSubset {
-    bluechip_denom: String,
-}
-
-#[derive(Deserialize)]
-struct FactoryInstantiateResponseSubset {
-    factory: FactoryConfigSubset,
-}
-
-const CONTRACT_NAME: &str = "crates.io:expand-economy";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-/// Load `CONFIG` and require the sender to match `config.owner`.
-fn load_config_as_owner(storage: &dyn Storage, sender: &Addr) -> Result<Config, ContractError> {
-    let config = CONFIG.load(storage)?;
-    if sender != config.owner {
-        return Err(ContractError::Unauthorized {});
-    }
-    Ok(config)
-}
-
-/// Validate a Cosmos SDK native bank denom against the documented
-/// format rules: 3–128 characters, must start with an ASCII letter, and
-/// the rest must be alphanumeric or one of `/`, `:`, `.`, `_`, `-`.
-/// Mirrors the cosmos-sdk `IsValidDenom` regex
-/// `^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$` without pulling in the `regex`
-/// crate (which would balloon the wasm output).
-///
-/// Catches the operator-typo class of failures at propose / instantiate
-/// time rather than 48 hours later when an apply lands a malformed
-/// denom and every subsequent `RequestExpansion` reverts inside the
-/// bank module with an error nobody is watching for. Examples this
-/// catches that the previous "non-empty after trim" check missed:
-///   - `"Bluechip"`           (capital first letter — bank rejects)
-///   - `"u bluechip"`         (whitespace inside)
-///   - `"u"` or `"ub"`        (length < 3)
-///   - `"1ubluechip"`         (digit prefix)
-///   - `"ubluechip!"`         (punctuation outside the allowed set)
-///
-/// Accepts all the cosmos-sdk shapes this contract actually wants:
-///   - `"ubluechip"`          (canonical native denom)
-///   - `"ucustom"`            (test fixture)
-///   - `"ibc/27394FB..."`     (IBC-wrapped — slashes + hex)
-///   - `"factory/cosmos1.../tokenname"` (tokenfactory shape)
-fn validate_native_denom(denom: &str) -> Result<(), ContractError> {
-    let len = denom.len();
-    if !(3..=128).contains(&len) {
-        return Err(ContractError::Std(StdError::generic_err(format!(
-            "bluechip_denom \"{}\" length {} is outside the cosmos-sdk \
-             allowed range [3, 128]",
-            denom, len
-        ))));
-    }
-    let mut chars = denom.chars();
-    let first = chars.next().expect("checked length >= 3");
-    if !first.is_ascii_alphabetic() {
-        return Err(ContractError::Std(StdError::generic_err(format!(
-            "bluechip_denom \"{}\" must start with an ASCII letter; got \
-             leading character '{}'",
-            denom, first
-        ))));
-    }
-    for c in chars {
-        let allowed = c.is_ascii_alphanumeric() || matches!(c, '/' | ':' | '.' | '_' | '-');
-        if !allowed {
-            return Err(ContractError::Std(StdError::generic_err(format!(
-                "bluechip_denom \"{}\" contains disallowed character '{}'; \
-                 cosmos-sdk denoms accept only alphanumerics and / : . _ -",
-                denom, c
-            ))));
-        }
-    }
-    Ok(())
-}
-
-/// Error with `err_msg` if `item` is already populated.
-fn ensure_absent<T>(
-    storage: &dyn Storage,
-    item: &Item<T>,
-    err_msg: &str,
-) -> Result<(), ContractError>
-where
-    T: Serialize + DeserializeOwned,
-{
-    if item.may_load(storage)?.is_some() {
-        return Err(ContractError::Std(StdError::generic_err(err_msg)));
-    }
-    Ok(())
-}
-
-/// Load `item` or return `ContractError::Std(generic_err(err_msg))`.
-fn load_or_err<T>(
-    storage: &dyn Storage,
-    item: &Item<T>,
-    err_msg: &str,
-) -> Result<T, ContractError>
-where
-    T: Serialize + DeserializeOwned,
-{
-    item.may_load(storage)?
-        .ok_or_else(|| ContractError::Std(StdError::generic_err(err_msg)))
-}
+use crate::{CONTRACT_NAME, CONTRACT_VERSION};
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -185,10 +58,10 @@ pub fn instantiate(
     CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::new()
-        .add_attribute("action", "instantiate")
-        .add_attribute("factory", config.factory_address)
-        .add_attribute("owner", config.owner)
-        .add_attribute("bluechip_denom", config.bluechip_denom))
+        .add_attribute(attrs::ACTION, attrs::INSTANTIATE)
+        .add_attribute(attrs::FACTORY, &config.factory_address)
+        .add_attribute(attrs::OWNER, &config.owner)
+        .add_attribute(attrs::BLUECHIP_DENOM, &config.bluechip_denom))
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -232,476 +105,29 @@ pub fn execute(
     }
 }
 
-pub fn execute_expand_economy(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    msg: ExpandEconomyMsg,
-) -> Result<Response, ContractError> {
-    let config = CONFIG.load(deps.storage)?;
-
-    if info.sender != config.factory_address {
-        return Err(ContractError::Unauthorized {});
-    }
-
-    // Cross-validate the factory's `bluechip_denom` against this contract's
-    // configured denom. Both fields are independently admin-mutable (each
-    // contract has its own propose/apply config flow with separate 48h
-    // timelocks), so they can drift if a single-side update is forgotten.
-    // Drift would silently fund rewards in the wrong denom — better to
-    // refuse the call and surface the mismatch loudly.
-    //
-    // One additional cross-contract query per RequestExpansion. Cost is
-    // negligible: the call fires only on threshold-crossing events, not
-    // on hot paths.
-    let factory_resp: FactoryInstantiateResponseSubset = deps
-        .querier
-        .query_wasm_smart(&config.factory_address, &FactoryQuery::Factory {})
-        .map_err(|e| {
-            ContractError::Std(StdError::generic_err(format!(
-                "Failed to query factory config for denom validation: {}",
-                e
-            )))
-        })?;
-    if factory_resp.factory.bluechip_denom != config.bluechip_denom {
-        return Err(ContractError::Std(StdError::generic_err(format!(
-            "bluechip_denom mismatch: factory has \"{}\", expand-economy has \"{}\". \
-             Update one side via its config-update flow before retrying.",
-            factory_resp.factory.bluechip_denom, config.bluechip_denom
-        ))));
-    }
-
-    match msg {
-        ExpandEconomyMsg::RequestExpansion { recipient, amount } => {
-            if amount.is_zero() {
-                // The factory's bluechip mint-decay polynomial drops to zero
-                // once `pool_id` and `seconds_elapsed` grow past the curve's
-                // crossover. Once it does, this contract is "dormant" by
-                // design — there is no more bluechip-economy expansion to
-                // dispense, and the mechanism's job is done. Surface that
-                // explicitly so operators and monitoring can distinguish
-                // "skipped because schedule has expired" from "skipped
-                // because of a bug".
-                return Ok(Response::new()
-                    .add_attribute("action", "request_reward_skipped")
-                    .add_attribute("reason", "economy_dormant")
-                    .add_attribute(
-                        "note",
-                        "ExpandEconomy mint schedule has reached zero; \
-                         no further expansions will be dispensed. This \
-                         is the intended end-state of the decay curve.",
-                    ));
-            }
-
-            // Validate the recipient at the contract boundary rather than
-            // letting a malformed string surface as an opaque bank-module
-            // error deep in the tx pipeline. Also guards against callers
-            // accidentally forwarding an IBC-wrapped / wrong-prefix string.
-            let recipient_addr = deps.api.addr_validate(&recipient)?;
-
-            // Per-recipient rate limit. Defends against `RetryFactoryNotify`
-            // storms compressing many threshold-mint payouts into a single
-            // burst that empties the rolling daily budget. Per-pool would
-            // require including the pool's controlling identity to be
-            // effective, eliminating retry permissionlessness; per-recipient
-            // keeps retry permissionless while bounding the worst-case rate
-            // at one payout per RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS to
-            // any single bluechip wallet. Enforced on the recipient address
-            // (the factory passes `bluechip_wallet_address` here), so it
-            // also globally rate-limits the typical single-recipient
-            // deployment. Stamped only on a successful payout below.
-            let now = env.block.time;
-            if let Some(last) =
-                LAST_EXPANSION_AT_RECIPIENT.may_load(deps.storage, recipient_addr.as_str())?
-            {
-                let next_allowed = last.plus_seconds(RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS);
-                if now < next_allowed {
-                    return Err(ContractError::Std(StdError::generic_err(format!(
-                        "Rate-limited: recipient {} can receive another expansion payout at {} \
-                         (last payout {}, cooldown {}s)",
-                        recipient_addr, next_allowed, last, RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS
-                    ))));
-                }
-            }
-
-            // Rolling 24-hour spend cap. Defense-in-depth against a
-            // compromised factory key forwarding huge RequestExpansion
-            // calls. The legitimate threshold-mint schedule is well below
-            // DAILY_EXPANSION_CAP per day; an attacker with full factory
-            // control can extract at most CAP per 24-hour window via this
-            // path. Window resets opportunistically on the first call after
-            // expiry rather than continuously, which is fine for cap
-            // semantics — see ExpansionWindow doc.
-            let window = match EXPANSION_WINDOW.may_load(deps.storage)? {
-                Some(w)
-                    if now.seconds().saturating_sub(w.window_start.seconds())
-                        < DAILY_WINDOW_SECONDS =>
-                {
-                    w
-                }
-                _ => ExpansionWindow {
-                    window_start: now,
-                    spent_in_window: Uint128::zero(),
-                },
-            };
-            let new_spent = window.spent_in_window.checked_add(amount)?;
-            if new_spent > DAILY_EXPANSION_CAP {
-                return Err(ContractError::DailyExpansionCapExceeded {
-                    requested: amount,
-                    spent_in_window: window.spent_in_window,
-                    cap: DAILY_EXPANSION_CAP,
-                });
-            }
-
-            // Graceful no-op when the contract's balance is below the
-            // requested amount. Running out of expand-economy funds is the
-            // INTENDED end-state: the contract is a finite "bluechip mint
-            // boost" reservoir that drains as the early ecosystem grows,
-            // tapering rewards toward zero by design. A failed BankMsg
-            // here would propagate up through `NotifyThresholdCrossed` and
-            // revert the entire factory tx, which would in turn leave the
-            // pool's `IS_THRESHOLD_HIT = true` state in place but force
-            // operators to chase the failed mint via `RetryFactoryNotify`
-            // forever. Instead, log the skip and return Ok so threshold
-            // crossings continue to settle cleanly even when the reservoir
-            // is empty.
-            let balance = deps
-                .querier
-                .query_balance(env.contract.address.as_str(), &config.bluechip_denom)?;
-            if balance.amount < amount {
-                return Ok(Response::new()
-                    .add_attribute("action", "request_reward_skipped")
-                    .add_attribute("reason", "insufficient_balance")
-                    .add_attribute("recipient", recipient_addr)
-                    .add_attribute("requested_amount", amount)
-                    .add_attribute("contract_balance", balance.amount)
-                    .add_attribute("denom", config.bluechip_denom));
-            }
-
-            // Persist the rolling-window debit only after balance check
-            // passes, so a skipped (insufficient_balance) request doesn't
-            // burn cap budget that the protocol could spend later when
-            // the contract is refunded.
-            EXPANSION_WINDOW.save(
-                deps.storage,
-                &ExpansionWindow {
-                    window_start: window.window_start,
-                    spent_in_window: new_spent,
-                },
-            )?;
-
-            // Stamp the per-recipient rate-limit timestamp on the success
-            // path only — a skipped (insufficient_balance) payout above
-            // returned early without reaching here, so the recipient is
-            // not penalized for outages of the reservoir. CosmWasm reverts
-            // every storage write on Err, so a downstream failure (e.g.
-            // BankMsg dispatch error) atomically rolls back this stamp
-            // along with the window debit.
-            LAST_EXPANSION_AT_RECIPIENT.save(
-                deps.storage,
-                recipient_addr.as_str(),
-                &now,
-            )?;
-
-            let send_msg = BankMsg::Send {
-                to_address: recipient_addr.to_string(),
-                amount: vec![Coin {
-                    denom: config.bluechip_denom.clone(),
-                    amount,
-                }],
-            };
-
-            Ok(Response::new()
-                .add_message(send_msg)
-                .add_attribute("action", "request_reward")
-                .add_attribute("recipient", recipient_addr)
-                .add_attribute("amount", amount)
-                .add_attribute("denom", config.bluechip_denom)
-                .add_attribute("spent_in_window_after", new_spent)
-                .add_attribute("daily_cap", DAILY_EXPANSION_CAP))
-        }
-    }
-}
-
-pub fn execute_propose_config_update(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    factory_address: Option<String>,
-    owner: Option<String>,
-    bluechip_denom: Option<String>,
-) -> Result<Response, ContractError> {
-    load_config_as_owner(deps.storage, &info.sender)?;
-    ensure_absent(
-        deps.storage,
-        &PENDING_CONFIG_UPDATE,
-        "A config update is already pending. Cancel it first.",
-    )?;
-
-    // Validate addresses early so invalid proposals fail at propose time
-    if let Some(ref addr) = factory_address {
-        deps.api.addr_validate(addr)?;
-    }
-    if let Some(ref addr) = owner {
-        deps.api.addr_validate(addr)?;
-    }
-    // Full cosmos-sdk denom format validation at propose time.
-    // Operator typos surface 48h earlier than they otherwise would
-    // (when someone tries to apply and every subsequent
-    // `RequestExpansion` breaks).
-    if let Some(ref d) = bluechip_denom {
-        validate_native_denom(d)?;
-    }
-
-    let effective_after = env.block.time.plus_seconds(CONFIG_TIMELOCK_SECONDS);
-
-    PENDING_CONFIG_UPDATE.save(
-        deps.storage,
-        &PendingConfigUpdate {
-            factory_address,
-            owner,
-            bluechip_denom,
-            effective_after,
-        },
-    )?;
-
-    Ok(Response::new()
-        .add_attribute("action", "propose_config_update")
-        .add_attribute("effective_after", effective_after.to_string()))
-}
-
-pub fn execute_apply_config_update(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-) -> Result<Response, ContractError> {
-    let mut config = load_config_as_owner(deps.storage, &info.sender)?;
-    let pending = load_or_err(
-        deps.storage,
-        &PENDING_CONFIG_UPDATE,
-        "No pending config update to execute",
-    )?;
-
-    if env.block.time < pending.effective_after {
-        return Err(ContractError::Std(StdError::generic_err(format!(
-            "Timelock not expired. Execute after: {}",
-            pending.effective_after
-        ))));
-    }
-
-    if let Some(factory) = pending.factory_address {
-        config.factory_address = deps.api.addr_validate(&factory)?;
-    }
-    if let Some(new_owner) = pending.owner {
-        config.owner = deps.api.addr_validate(&new_owner)?;
-    }
-    if let Some(new_denom) = pending.bluechip_denom {
-        // Full denom format validation was already enforced at
-        // propose time; re-check here as defense-in-depth in case a
-        // future migration ever inserts a PendingConfigUpdate directly,
-        // bypassing propose. Cheap to repeat (no I/O), and locks the
-        // invariant on the apply path too.
-        validate_native_denom(&new_denom)?;
-        config.bluechip_denom = new_denom;
-    }
-
-    CONFIG.save(deps.storage, &config)?;
-    PENDING_CONFIG_UPDATE.remove(deps.storage);
-
-    Ok(Response::new()
-        .add_attribute("action", "execute_config_update")
-        .add_attribute("factory", config.factory_address)
-        .add_attribute("owner", config.owner)
-        .add_attribute("bluechip_denom", config.bluechip_denom))
-}
-
-pub fn execute_cancel_config_update(
-    deps: DepsMut,
-    info: MessageInfo,
-) -> Result<Response, ContractError> {
-    load_config_as_owner(deps.storage, &info.sender)?;
-    load_or_err(
-        deps.storage,
-        &PENDING_CONFIG_UPDATE,
-        "No pending config update to cancel",
-    )?;
-    PENDING_CONFIG_UPDATE.remove(deps.storage);
-    Ok(Response::new().add_attribute("action", "cancel_config_update"))
-}
-
-pub fn execute_propose_withdrawal(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-    amount: Uint128,
-    denom: String,
-    recipient: Option<String>,
-) -> Result<Response, ContractError> {
-    load_config_as_owner(deps.storage, &info.sender)?;
-    ensure_absent(
-        deps.storage,
-        &PENDING_WITHDRAWAL,
-        "A withdrawal is already pending. Cancel it first.",
-    )?;
-
-    let target = recipient.unwrap_or_else(|| info.sender.to_string());
-    deps.api.addr_validate(&target)?;
-    validate_native_denom(&denom)?;
-
-    let execute_after = env.block.time.plus_seconds(WITHDRAW_TIMELOCK_SECONDS);
-    PENDING_WITHDRAWAL.save(
-        deps.storage,
-        &PendingWithdrawal {
-            amount,
-            denom: denom.clone(),
-            recipient: target.clone(),
-            execute_after,
-        },
-    )?;
-
-    Ok(Response::new()
-        .add_attribute("action", "propose_withdrawal")
-        .add_attribute("recipient", target)
-        .add_attribute("amount", amount)
-        .add_attribute("denom", denom)
-        .add_attribute("execute_after", execute_after.to_string()))
-}
-
-pub fn execute_withdrawal(
-    deps: DepsMut,
-    env: Env,
-    info: MessageInfo,
-) -> Result<Response, ContractError> {
-    load_config_as_owner(deps.storage, &info.sender)?;
-    let pending = load_or_err(
-        deps.storage,
-        &PENDING_WITHDRAWAL,
-        "No pending withdrawal to execute",
-    )?;
-
-    if env.block.time < pending.execute_after {
-        return Err(ContractError::Std(StdError::generic_err(format!(
-            "Timelock not expired. Execute after: {}",
-            pending.execute_after
-        ))));
-    }
-
-    PENDING_WITHDRAWAL.remove(deps.storage);
-
-    // Clamp the requested amount to the contract's current balance so a
-    // proposed-but-stale withdrawal (e.g. balance drew down via
-    // RequestExpansion between propose and execute) doesn't fail the
-    // whole tx at the bank module. Transfer the smaller of (requested,
-    // balance) and emit both values so the caller can detect the clamp.
-    let balance = deps
-        .querier
-        .query_balance(env.contract.address.as_str(), &pending.denom)?;
-    let amount_to_send = pending.amount.min(balance.amount);
-
-    let mut response = Response::new()
-        .add_attribute("action", "execute_withdrawal")
-        .add_attribute("recipient", pending.recipient.clone())
-        .add_attribute("requested_amount", pending.amount)
-        .add_attribute("amount", amount_to_send)
-        .add_attribute("contract_balance", balance.amount)
-        .add_attribute("denom", pending.denom.clone());
-
-    if !amount_to_send.is_zero() {
-        let send_msg = BankMsg::Send {
-            to_address: pending.recipient.clone(),
-            amount: vec![Coin {
-                denom: pending.denom,
-                amount: amount_to_send,
-            }],
-        };
-        response = response.add_message(send_msg);
-    } else {
-        response = response.add_attribute("note", "no funds available; withdrawal skipped");
-    }
-
-    Ok(response)
-}
-
-pub fn execute_cancel_withdrawal(
-    deps: DepsMut,
-    info: MessageInfo,
-) -> Result<Response, ContractError> {
-    load_config_as_owner(deps.storage, &info.sender)?;
-    load_or_err(
-        deps.storage,
-        &PENDING_WITHDRAWAL,
-        "No pending withdrawal to cancel",
-    )?;
-    PENDING_WITHDRAWAL.remove(deps.storage);
-    Ok(Response::new().add_attribute("action", "cancel_withdrawal"))
-}
-
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {
-        QueryMsg::GetConfig {} => to_json_binary(&query_config(deps)?),
+        QueryMsg::GetConfig {} => to_json_binary(&query_config(deps)?).map_err(map_std),
         QueryMsg::GetBalance { denom } => {
-            to_json_binary(&deps.querier.query_balance(env.contract.address, denom)?)
+            // Pass `&env.contract.address` (a `&Addr` reference) consistently
+            // with the rest of this crate's `query_balance` call sites.
+            to_json_binary(&deps.querier.query_balance(&env.contract.address, denom)?)
+                .map_err(map_std)
         }
     }
 }
 
-// ---------------------------------------------------------------------------
-// Migrate
-// ---------------------------------------------------------------------------
-
-/// Without this entry point the chain rejects every
-/// `MsgMigrateContract` at runtime with "no migrate function exported",
-/// which would leave this contract effectively immutable despite cw2
-/// being initialised at instantiate time. Mirrors the downgrade
-/// guard the pool / factory contracts already use:
-///
-///   - parse the cw2-stored version + the compile-time CONTRACT_VERSION
-///     as semver; reject any migrate where stored > current
-///   - tolerate a missing cw2 entry (legacy / test fixtures), skipping
-///     the comparison rather than erroring
-///   - bump the cw2 record on success so subsequent migrates see the
-///     new version
-///
-/// `MigrateMsg::UpdateVersion {}` is the no-op variant — it exists so
-/// operators have an explicit "just bump the version, no other state
-/// changes" path. Future variants can carry parameters; the downgrade
-/// guard runs unconditionally first so they all benefit.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-    if let Ok(stored_version) = cw2::get_contract_version(deps.storage) {
-        let stored_semver: semver::Version = stored_version.version.parse().map_err(|e| {
-            ContractError::Std(StdError::generic_err(format!(
-                "stored contract version {} is not valid semver: {}",
-                stored_version.version, e
-            )))
-        })?;
-        let current_semver: semver::Version = CONTRACT_VERSION.parse().map_err(|e| {
-            ContractError::Std(StdError::generic_err(format!(
-                "current contract version {} is not valid semver: {}",
-                CONTRACT_VERSION, e
-            )))
-        })?;
-        if stored_semver > current_semver {
-            return Err(ContractError::Std(StdError::generic_err(format!(
-                "Migration would downgrade contract from {} to {}; refusing.",
-                stored_semver, current_semver
-            ))));
-        }
-    }
-
-    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-    match msg {
-        MigrateMsg::UpdateVersion {} => Ok(Response::new()
-            .add_attribute("action", "migrate")
-            .add_attribute("variant", "update_version")
-            .add_attribute("contract_name", CONTRACT_NAME)
-            .add_attribute("contract_version", CONTRACT_VERSION)),
-    }
+pub fn migrate(
+    deps: DepsMut,
+    env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, ContractError> {
+    crate::migrate::migrate(deps, env, msg)
 }
 
-fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+fn query_config(deps: Deps) -> Result<ConfigResponse, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     Ok(ConfigResponse {
         factory_address: config.factory_address,
@@ -710,28 +136,27 @@ fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     })
 }
 
+#[inline]
+fn map_std(e: StdError) -> ContractError {
+    ContractError::Std(e)
+}
+
 // ---------------------------------------------------------------------------
 // Test-only re-exports
 // ---------------------------------------------------------------------------
 //
-// `validate_native_denom` and the factory-response subset structs are
-// `fn`-private / non-`pub` by design — they're internal plumbing for
-// the cross-validation + denom-format paths and shouldn't be part of
-// this contract's public API. The audit-tests in `crate::audit_tests`
-// need to exercise them directly (round-trip + unit tests on the
-// validator), so we expose them through a `cfg(test)` module rather
-// than weakening the production visibility.
+// The test suite needs to exercise `validate_native_denom` and the
+// factory-response subset structs directly. Both are crate-private in
+// production; expose them through a `cfg(test)` module rather than
+// weakening their visibility for the live build.
 
 #[cfg(test)]
 pub mod testing {
-    use super::FactoryInstantiateResponseSubset as Subset;
     use crate::error::ContractError;
     use serde::Deserialize;
 
-    /// Re-export of the private subset struct so tests can
-    /// deserialize a synthetic factory response directly. Repeats the
-    /// shape rather than re-exposing the original to keep the
-    /// production type private.
+    /// Re-export of the private subset struct so tests can deserialize
+    /// a synthetic factory response directly.
     #[derive(Deserialize)]
     pub struct FactoryConfigSubsetForTest {
         pub bluechip_denom: String,
@@ -742,17 +167,8 @@ pub mod testing {
         pub factory: FactoryConfigSubsetForTest,
     }
 
-    /// Compile-time assertion that the test subset stays bit-identical
-    /// to the production one. If a future change adds a field to the
-    /// production subset without the test subset, this fails to
-    /// compile — forcing a co-ordinated update.
-    const _: fn() = || {
-        fn assert_same_shape(_p: &Subset, _t: &FactoryInstantiateResponseSubsetForTest) {}
-        // Both deserialize the same JSON to the same field set today.
-    };
-
     /// Re-export of the validator for unit tests.
     pub fn validate_native_denom_for_test(denom: &str) -> Result<(), ContractError> {
-        super::validate_native_denom(denom)
+        crate::denom::validate_native_denom(denom)
     }
 }

--- a/expand-economy/src/denom.rs
+++ b/expand-economy/src/denom.rs
@@ -1,0 +1,60 @@
+//! Native bank denom validator. Mirrors the cosmos-sdk `IsValidDenom`
+//! regex `^[a-zA-Z][a-zA-Z0-9/:._-]{2,127}$` without pulling the
+//! `regex` crate (which would balloon the wasm output).
+
+use crate::error::{ContractError, InvalidDenomReason};
+
+/// Validate a Cosmos SDK native bank denom against the documented
+/// format rules: 3–128 characters, must start with an ASCII letter, and
+/// the rest must be alphanumeric or one of `/`, `:`, `.`, `_`, `-`.
+///
+/// Catches the operator-typo class of failures at propose / instantiate
+/// time rather than 48 hours later when an apply lands a malformed
+/// denom and every subsequent `RequestExpansion` reverts inside the
+/// bank module with an error nobody is watching for. Examples this
+/// catches that the previous "non-empty after trim" check missed:
+///   - `"Bluechip"`           (capital first letter — bank rejects)
+///   - `"u bluechip"`         (whitespace inside)
+///   - `"u"` or `"ub"`        (length < 3)
+///   - `"1ubluechip"`         (digit prefix)
+///   - `"ubluechip!"`         (punctuation outside the allowed set)
+///
+/// Accepts all the cosmos-sdk shapes this contract actually wants:
+///   - `"ubluechip"`          (canonical native denom)
+///   - `"ucustom"`            (test fixture)
+///   - `"ibc/27394FB..."`     (IBC-wrapped — slashes + hex)
+///   - `"factory/cosmos1.../tokenname"` (tokenfactory shape)
+pub fn validate_native_denom(denom: &str) -> Result<(), ContractError> {
+    let len = denom.len();
+    if !(3..=128).contains(&len) {
+        return Err(ContractError::InvalidDenom {
+            denom: denom.to_string(),
+            reason: InvalidDenomReason::LengthOutOfRange { len },
+        });
+    }
+    let mut chars = denom.chars();
+    let Some(first) = chars.next() else {
+        // Length is in [3, 128] above, so an empty `chars()` would be a
+        // logic bug — surface explicitly rather than panicking.
+        return Err(ContractError::InvalidDenom {
+            denom: denom.to_string(),
+            reason: InvalidDenomReason::LengthOutOfRange { len: 0 },
+        });
+    };
+    if !first.is_ascii_alphabetic() {
+        return Err(ContractError::InvalidDenom {
+            denom: denom.to_string(),
+            reason: InvalidDenomReason::BadLeadingCharacter { first },
+        });
+    }
+    for ch in chars {
+        let allowed = ch.is_ascii_alphanumeric() || matches!(ch, '/' | ':' | '.' | '_' | '-');
+        if !allowed {
+            return Err(ContractError::InvalidDenom {
+                denom: denom.to_string(),
+                reason: InvalidDenomReason::DisallowedCharacter { ch },
+            });
+        }
+    }
+    Ok(())
+}

--- a/expand-economy/src/error.rs
+++ b/expand-economy/src/error.rs
@@ -1,6 +1,22 @@
-use cosmwasm_std::{OverflowError, StdError, Uint128};
+use cosmwasm_std::{OverflowError, StdError, Timestamp, Uint128};
 use cw_utils::PaymentError;
 use thiserror::Error;
+
+/// Reason a `bluechip_denom` failed [`crate::denom::validate_native_denom`].
+/// Lets clients distinguish "wrong length" from "wrong leading char" from
+/// "bad inner character" without parsing English error messages.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum InvalidDenomReason {
+    #[error("length {len} is outside the cosmos-sdk allowed range [3, 128]")]
+    LengthOutOfRange { len: usize },
+    #[error("must start with an ASCII letter; got leading character '{first}'")]
+    BadLeadingCharacter { first: char },
+    #[error(
+        "contains disallowed character '{ch}'; cosmos-sdk denoms accept only \
+         alphanumerics and / : . _ -"
+    )]
+    DisallowedCharacter { ch: char },
+}
 
 #[derive(Error, Debug)]
 pub enum ContractError {
@@ -23,6 +39,71 @@ pub enum ContractError {
     /// funds") is preserved for clients.
     #[error("{0}")]
     Payment(#[from] PaymentError),
+
+    // -----------------------------------------------------------------
+    // Domain-specific variants. Replace earlier `Std(generic_err(...))`
+    // sites so off-chain consumers can match structurally rather than
+    // regex an English message.
+    // -----------------------------------------------------------------
+    #[error(
+        "Rate-limited: recipient {recipient} can receive another expansion \
+         payout at {next_allowed} (last payout {last}, cooldown {cooldown_seconds}s)"
+    )]
+    RecipientRateLimited {
+        recipient: String,
+        next_allowed: Timestamp,
+        last: Timestamp,
+        cooldown_seconds: u64,
+    },
+
+    #[error("Timelock not expired. Execute after: {ready_at}")]
+    TimelockNotExpired { ready_at: Timestamp },
+
+    #[error(
+        "bluechip_denom mismatch: factory has \"{factory}\", expand-economy \
+         has \"{expand_economy}\". Update one side via its config-update flow \
+         before retrying."
+    )]
+    BluechipDenomMismatch {
+        factory: String,
+        expand_economy: String,
+    },
+
+    #[error("Failed to query factory config for denom validation: {reason}")]
+    FactoryQueryFailed { reason: String },
+
+    #[error("A config update is already pending. Cancel it first.")]
+    ConfigUpdateAlreadyPending,
+
+    #[error("A withdrawal is already pending. Cancel it first.")]
+    WithdrawalAlreadyPending,
+
+    #[error("No pending config update to execute")]
+    NoPendingConfigUpdateToExecute,
+
+    #[error("No pending config update to cancel")]
+    NoPendingConfigUpdateToCancel,
+
+    #[error("No pending withdrawal to execute")]
+    NoPendingWithdrawalToExecute,
+
+    #[error("No pending withdrawal to cancel")]
+    NoPendingWithdrawalToCancel,
+
+    #[error("bluechip_denom \"{denom}\" is invalid: {reason}")]
+    InvalidDenom {
+        denom: String,
+        reason: InvalidDenomReason,
+    },
+
+    #[error("Migration would downgrade contract from {stored} to {current}; refusing.")]
+    DowngradeRefused { stored: String, current: String },
+
+    #[error("Stored cw2 contract version {version} is not valid semver: {msg}")]
+    StoredVersionInvalid { version: String, msg: String },
+
+    #[error("Compile-time CONTRACT_VERSION {version} is not valid semver: {msg}")]
+    CurrentVersionInvalid { version: String, msg: String },
 }
 
 impl From<OverflowError> for ContractError {

--- a/expand-economy/src/expand.rs
+++ b/expand-economy/src/expand.rs
@@ -1,0 +1,250 @@
+//! `RequestExpansion` handler, decomposed into one helper per phase so
+//! the dispatcher stays under ~25 lines. Each helper is independently
+//! unit-testable and documents one concern.
+//!
+//! Phase ordering (load-bearing, do not reorder without re-validating
+//! the cap and rate-limit invariants):
+//!   1. authorise the caller as the configured factory
+//!   2. cross-validate the factory's `bluechip_denom` against ours
+//!   3. zero-amount short-circuit — dormant economy is success, not failure
+//!   4. validate the recipient address
+//!   5. per-recipient rate-limit gate (cheapest gate, blocks retry storms
+//!      before they touch the cap)
+//!   6. rolling 24h window cap — checked but NOT persisted yet
+//!   7. balance check — graceful skip without burning cap or rate-limit
+//!   8. persist window debit + recipient stamp atomically
+//!   9. dispatch BankMsg
+//!
+//! Steps 6-8 must stay in this order: persisting before the balance
+//! check would burn cap budget on skipped requests; persisting after
+//! dispatch is atomic in CosmWasm but adds no benefit.
+
+use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, MessageInfo, Response, Storage, Timestamp, Uint128};
+
+use crate::attrs;
+use crate::error::ContractError;
+use crate::factory_query::cross_validate_factory_denom;
+use crate::msg::ExpandEconomyMsg;
+use crate::state::{
+    Config, ExpansionWindow, CONFIG, DAILY_EXPANSION_CAP, DAILY_WINDOW_SECONDS, EXPANSION_WINDOW,
+    LAST_EXPANSION_AT_RECIPIENT, RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS,
+};
+
+/// Top-level entry point. See file-level comment for phase ordering.
+pub fn execute_expand_economy(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExpandEconomyMsg,
+) -> Result<Response, ContractError> {
+    let config = require_factory_caller(deps.storage, &info.sender)?;
+    cross_validate_factory_denom(deps.as_ref(), &config)?;
+
+    let ExpandEconomyMsg::RequestExpansion { recipient, amount } = msg;
+
+    if amount.is_zero() {
+        return Ok(dormant_response());
+    }
+
+    let recipient_addr = deps.api.addr_validate(&recipient)?;
+    enforce_recipient_rate_limit(deps.storage, &recipient_addr, env.block.time)?;
+
+    let (window, new_spent) =
+        check_and_compute_window(deps.storage, env.block.time, amount)?;
+
+    if let Some(skip) =
+        maybe_skip_for_balance(deps.as_ref(), &env, &config, &recipient_addr, amount)?
+    {
+        return Ok(skip);
+    }
+
+    persist_expansion_state(deps.storage, &recipient_addr, env.block.time, window, new_spent)?;
+    Ok(payout_response(&config, &recipient_addr, amount, new_spent))
+}
+
+/// Phase 1: load `CONFIG` and require the sender to match the
+/// configured factory address.
+fn require_factory_caller(
+    storage: &dyn Storage,
+    sender: &Addr,
+) -> Result<Config, ContractError> {
+    let config = CONFIG.load(storage)?;
+    if sender != config.factory_address {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(config)
+}
+
+/// Phase 3: response for the zero-amount path. The factory's bluechip
+/// mint-decay polynomial drops to zero once the curve crossover is
+/// passed; once it does, this contract is "dormant" by design — there
+/// is no more bluechip-economy expansion to dispense, and the
+/// mechanism's job is done. Surface that explicitly so operators and
+/// monitoring can distinguish "skipped because schedule has expired"
+/// from "skipped because of a bug".
+fn dormant_response() -> Response {
+    Response::new()
+        .add_attribute(attrs::ACTION, attrs::REQUEST_REWARD_SKIPPED)
+        .add_attribute(attrs::REASON, attrs::REASON_ECONOMY_DORMANT)
+        .add_attribute(attrs::NOTE, attrs::NOTE_ECONOMY_DORMANT)
+}
+
+/// Phase 5: per-recipient rate limit. Defends against
+/// `RetryFactoryNotify` storms compressing many threshold-mint payouts
+/// into a single burst that empties the rolling daily budget.
+/// Per-pool would require including the pool's controlling identity
+/// to be effective, eliminating retry permissionlessness; per-recipient
+/// keeps retry permissionless while bounding the worst-case rate at
+/// one payout per `RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS` to any
+/// single bluechip wallet. Stamped only on the success path in
+/// `persist_expansion_state` below.
+fn enforce_recipient_rate_limit(
+    storage: &dyn Storage,
+    recipient_addr: &Addr,
+    now: Timestamp,
+) -> Result<(), ContractError> {
+    if let Some(last) =
+        LAST_EXPANSION_AT_RECIPIENT.may_load(storage, recipient_addr.as_str())?
+    {
+        let next_allowed = last.plus_seconds(RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS);
+        if now < next_allowed {
+            return Err(ContractError::RecipientRateLimited {
+                recipient: recipient_addr.to_string(),
+                next_allowed,
+                last,
+                cooldown_seconds: RECIPIENT_EXPANSION_RATE_LIMIT_SECONDS,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Phase 6: rolling 24-hour spend cap. Defense-in-depth against a
+/// compromised factory key forwarding huge `RequestExpansion` calls.
+/// The legitimate threshold-mint schedule is well below
+/// `DAILY_EXPANSION_CAP` per day; an attacker with full factory control
+/// can extract at most CAP per 24-hour window via this path.
+///
+/// Window resets opportunistically on the first call after expiry
+/// rather than continuously, which is fine for cap semantics — see
+/// [`crate::state::ExpansionWindow`] doc.
+///
+/// Returns the window record we'll persist (with the new
+/// `spent_in_window` already computed) plus the new running total so
+/// the response can include it without recomputing.
+fn check_and_compute_window(
+    storage: &dyn Storage,
+    now: Timestamp,
+    amount: Uint128,
+) -> Result<(ExpansionWindow, Uint128), ContractError> {
+    let window = match EXPANSION_WINDOW.may_load(storage)? {
+        Some(w)
+            if now.seconds().saturating_sub(w.window_start.seconds())
+                < DAILY_WINDOW_SECONDS =>
+        {
+            w
+        }
+        _ => ExpansionWindow {
+            window_start: now,
+            spent_in_window: Uint128::zero(),
+        },
+    };
+    let new_spent = window.spent_in_window.checked_add(amount)?;
+    if new_spent > DAILY_EXPANSION_CAP {
+        return Err(ContractError::DailyExpansionCapExceeded {
+            requested: amount,
+            spent_in_window: window.spent_in_window,
+            cap: DAILY_EXPANSION_CAP,
+        });
+    }
+    Ok((window, new_spent))
+}
+
+/// Phase 7: balance check + graceful skip.
+///
+/// Running out of expand-economy funds is the INTENDED end-state: the
+/// contract is a finite "bluechip mint boost" reservoir that drains as
+/// the early ecosystem grows, tapering rewards toward zero by design.
+/// A failed BankMsg here would propagate up through
+/// `NotifyThresholdCrossed` and revert the entire factory tx, which
+/// would in turn leave the pool's `IS_THRESHOLD_HIT = true` state in
+/// place but force operators to chase the failed mint via
+/// `RetryFactoryNotify` forever. Instead, log the skip and return
+/// `Some(skip_response)` so threshold crossings continue to settle
+/// cleanly even when the reservoir is empty.
+///
+/// Returns `None` when the contract has enough balance to dispense
+/// `amount`; the caller continues to the persist + dispatch phases.
+fn maybe_skip_for_balance(
+    deps: cosmwasm_std::Deps,
+    env: &Env,
+    config: &Config,
+    recipient_addr: &Addr,
+    amount: Uint128,
+) -> Result<Option<Response>, ContractError> {
+    let balance = deps
+        .querier
+        .query_balance(&env.contract.address, &config.bluechip_denom)?;
+    if balance.amount < amount {
+        return Ok(Some(
+            Response::new()
+                .add_attribute(attrs::ACTION, attrs::REQUEST_REWARD_SKIPPED)
+                .add_attribute(attrs::REASON, attrs::REASON_INSUFFICIENT_BALANCE)
+                .add_attribute(attrs::RECIPIENT, recipient_addr)
+                .add_attribute(attrs::REQUESTED_AMOUNT, amount)
+                .add_attribute(attrs::CONTRACT_BALANCE, balance.amount)
+                .add_attribute(attrs::DENOM, &config.bluechip_denom),
+        ));
+    }
+    Ok(None)
+}
+
+/// Phase 8: persist the rolling-window debit + the per-recipient
+/// rate-limit timestamp.
+///
+/// Order matters: skip-for-balance returned earlier without reaching
+/// here, so the recipient is not penalized for outages of the
+/// reservoir. CosmWasm reverts every storage write on Err, so a
+/// downstream failure (e.g. BankMsg dispatch error) atomically rolls
+/// back this stamp along with the window debit.
+fn persist_expansion_state(
+    storage: &mut dyn Storage,
+    recipient_addr: &Addr,
+    now: Timestamp,
+    window: ExpansionWindow,
+    new_spent: Uint128,
+) -> Result<(), ContractError> {
+    EXPANSION_WINDOW.save(
+        storage,
+        &ExpansionWindow {
+            window_start: window.window_start,
+            spent_in_window: new_spent,
+        },
+    )?;
+    LAST_EXPANSION_AT_RECIPIENT.save(storage, recipient_addr.as_str(), &now)?;
+    Ok(())
+}
+
+/// Phase 9: build the success response with the BankMsg attached.
+fn payout_response(
+    config: &Config,
+    recipient_addr: &Addr,
+    amount: Uint128,
+    new_spent: Uint128,
+) -> Response {
+    let send_msg = BankMsg::Send {
+        to_address: recipient_addr.to_string(),
+        amount: vec![Coin {
+            denom: config.bluechip_denom.clone(),
+            amount,
+        }],
+    };
+    Response::new()
+        .add_message(send_msg)
+        .add_attribute(attrs::ACTION, attrs::REQUEST_REWARD)
+        .add_attribute(attrs::RECIPIENT, recipient_addr)
+        .add_attribute(attrs::AMOUNT, amount)
+        .add_attribute(attrs::DENOM, &config.bluechip_denom)
+        .add_attribute(attrs::SPENT_IN_WINDOW_AFTER, new_spent)
+        .add_attribute(attrs::DAILY_CAP, DAILY_EXPANSION_CAP)
+}

--- a/expand-economy/src/factory_query.rs
+++ b/expand-economy/src/factory_query.rs
@@ -1,0 +1,86 @@
+//! Wire-format types + helper for cross-validating the factory's
+//! `bluechip_denom` against this contract's stored config. Lifted out of
+//! `contract.rs` so the wire-format-sensitive plain-serde derives and
+//! their justification live next to the `cross_validate_factory_denom`
+//! function that uses them.
+
+use cosmwasm_std::Deps;
+use serde::{Deserialize, Serialize};
+
+use crate::error::ContractError;
+use crate::state::Config;
+
+/// Minimal subset of the factory's query interface that this contract
+/// uses to cross-validate `bluechip_denom`. Defined locally to avoid a
+/// compile-time dependency on the `factory` crate (the two communicate
+/// only over wasm message boundaries).
+///
+/// Deliberately uses plain `#[derive(serde::Serialize)]` +
+/// explicit `rename_all = "snake_case"` rather than `#[cw_serde]`. The
+/// query message we send to the factory must match
+/// `factory::query::QueryMsg::Factory {}` on the wire — `cw_serde`
+/// adds `rename_all = "snake_case"` for enums via macro magic, which
+/// works today but couples our wire format to a tooling
+/// implementation detail. Using plain serde derives makes the wire
+/// contract explicit and resilient to future cosmwasm-schema changes.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FactoryQuery {
+    Factory {},
+}
+
+/// Wire-compatible subset of `factory::msg::FactoryInstantiateResponse`
+/// — only the field this contract reads.
+///
+/// Uses plain `#[derive(serde::Deserialize)]` rather than `#[cw_serde]`.
+/// `cw_serde` is documented in cosmwasm-schema 2.x today as NOT setting
+/// `deny_unknown_fields`, but that's a tooling default that could
+/// reasonably flip in a future release — and if it ever does, every
+/// `RequestExpansion` would fail with an opaque "unknown field"
+/// deserialization error inside `query_wasm_smart`, silently bricking
+/// every threshold-crossing bluechip mint.
+///
+/// Plain `#[derive(serde::Deserialize)]` does NOT add
+/// `deny_unknown_fields`, so the "extra factory-side fields are
+/// ignored" property is locked in by serde's documented default
+/// behavior rather than a transitive cosmwasm-schema choice. Combined
+/// with the round-trip test in `tests::factory_response_round_trip`,
+/// this future-proofs the cross-validation path.
+#[derive(Deserialize)]
+pub(crate) struct FactoryConfigSubset {
+    pub bluechip_denom: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct FactoryInstantiateResponseSubset {
+    pub factory: FactoryConfigSubset,
+}
+
+/// Cross-validate the factory's `bluechip_denom` against this
+/// contract's configured denom. Both fields are independently
+/// admin-mutable (each contract has its own propose/apply config flow
+/// with separate 48h timelocks), so they can drift if a single-side
+/// update is forgotten. Drift would silently fund rewards in the wrong
+/// denom — better to refuse the call and surface the mismatch loudly.
+///
+/// One additional cross-contract query per `RequestExpansion`. Cost is
+/// negligible: the call fires only on threshold-crossing events, not
+/// on hot paths.
+pub(crate) fn cross_validate_factory_denom(
+    deps: Deps,
+    config: &Config,
+) -> Result<(), ContractError> {
+    let factory_resp: FactoryInstantiateResponseSubset = deps
+        .querier
+        .query_wasm_smart(&config.factory_address, &FactoryQuery::Factory {})
+        .map_err(|e| ContractError::FactoryQueryFailed {
+            reason: e.to_string(),
+        })?;
+    if factory_resp.factory.bluechip_denom != config.bluechip_denom {
+        return Err(ContractError::BluechipDenomMismatch {
+            factory: factory_resp.factory.bluechip_denom,
+            expand_economy: config.bluechip_denom.clone(),
+        });
+    }
+    Ok(())
+}

--- a/expand-economy/src/helpers.rs
+++ b/expand-economy/src/helpers.rs
@@ -1,0 +1,96 @@
+//! Shared owner-gating + storage-item helpers used by `instantiate`,
+//! `execute`, and the timelock flows. Lifted out of `contract.rs` so
+//! every entry-point handler reaches them at the same depth.
+
+use cosmwasm_std::{Addr, DepsMut, MessageInfo, Response, Storage, Timestamp};
+use cw_storage_plus::Item;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::attrs;
+use crate::error::ContractError;
+use crate::state::{Config, CONFIG};
+
+/// Load `CONFIG` and require the sender to match `config.owner`.
+///
+/// `CONFIG` is set in `instantiate` and never removed — `load` (rather
+/// than `may_load`) is correct here, and produces a `StdError::NotFound`
+/// only as a programmer-error backstop. Every owner-gated handler
+/// funnels through this helper so the owner check exists in exactly one
+/// place.
+pub fn load_config_as_owner(
+    storage: &dyn Storage,
+    sender: &Addr,
+) -> Result<Config, ContractError> {
+    let config = CONFIG.load(storage)?;
+    if sender != config.owner {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(config)
+}
+
+/// Error with `err` if `item` is already populated. Used by the propose
+/// handlers to refuse a second pending update before the existing one is
+/// either applied or cancelled.
+pub fn ensure_absent<T>(
+    storage: &dyn Storage,
+    item: &Item<T>,
+    err: ContractError,
+) -> Result<(), ContractError>
+where
+    T: Serialize + DeserializeOwned,
+{
+    if item.may_load(storage)?.is_some() {
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Load `item` or return `err`. Replacement for `may_load + ok_or` at
+/// the apply / cancel sites so each timelock helper has one well-typed
+/// error per missing-pending case.
+pub fn load_or_err<T>(
+    storage: &dyn Storage,
+    item: &Item<T>,
+    err: ContractError,
+) -> Result<T, ContractError>
+where
+    T: Serialize + DeserializeOwned,
+{
+    item.may_load(storage)?.ok_or(err)
+}
+
+/// Reject if `now < ready_at`. Single source of truth for the
+/// "Timelock not expired" check shared by `ExecuteConfigUpdate` and
+/// `ExecuteWithdrawal`.
+pub fn require_timelock_expired(
+    now: Timestamp,
+    ready_at: Timestamp,
+) -> Result<(), ContractError> {
+    if now < ready_at {
+        return Err(ContractError::TimelockNotExpired { ready_at });
+    }
+    Ok(())
+}
+
+/// Owner-gated cancel for any timelocked `Item<T>`. Centralizes the
+/// shape:
+///
+///     load_config_as_owner -> load_or_err(missing) -> item.remove -> Response
+///
+/// shared by `CancelConfigUpdate` and `CancelWithdrawal`. Adding a
+/// third cancel path becomes a one-line call to this helper.
+pub fn owner_gated_cancel<T>(
+    deps: DepsMut,
+    info: MessageInfo,
+    item: &Item<T>,
+    missing_err: ContractError,
+    action: &'static str,
+) -> Result<Response, ContractError>
+where
+    T: Serialize + DeserializeOwned,
+{
+    load_config_as_owner(deps.storage, &info.sender)?;
+    load_or_err(deps.storage, item, missing_err)?;
+    item.remove(deps.storage);
+    Ok(Response::new().add_attribute(attrs::ACTION, action))
+}

--- a/expand-economy/src/lib.rs
+++ b/expand-economy/src/lib.rs
@@ -1,7 +1,14 @@
+pub mod attrs;
 pub mod contract;
+pub mod denom;
 pub mod error;
+pub mod expand;
+pub mod factory_query;
+pub mod helpers;
+pub mod migrate;
 pub mod msg;
 pub mod state;
+pub mod timelock;
 
 #[cfg(test)]
 mod audit_tests;
@@ -9,3 +16,10 @@ mod audit_tests;
 mod tests;
 
 pub use crate::error::ContractError;
+
+/// cw2 contract name persisted on every (re)instantiate and migrate.
+/// Centralized so a future re-publish under a different crate name
+/// only requires one edit.
+pub const CONTRACT_NAME: &str = "crates.io:expand-economy";
+/// cw2 contract version, sourced from Cargo.toml at compile time.
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/expand-economy/src/migrate.rs
+++ b/expand-economy/src/migrate.rs
@@ -1,0 +1,66 @@
+//! `migrate` entry point + downgrade guard. Mirrors the same shape used
+//! by the pool / factory contracts: tolerate a missing cw2 record
+//! (legacy / test fixtures), refuse stored > current, otherwise bump
+//! the cw2 record on success.
+
+use cosmwasm_std::{DepsMut, Env, Response};
+use cw2::set_contract_version;
+
+use crate::attrs;
+use crate::error::ContractError;
+use crate::msg::MigrateMsg;
+use crate::{CONTRACT_NAME, CONTRACT_VERSION};
+
+/// Without this entry point the chain rejects every
+/// `MsgMigrateContract` at runtime with "no migrate function exported",
+/// which would leave this contract effectively immutable despite cw2
+/// being initialised at instantiate time. Mirrors the downgrade
+/// guard the pool / factory contracts already use:
+///
+///   - parse the cw2-stored version + the compile-time `CONTRACT_VERSION`
+///     as semver; reject any migrate where stored > current
+///   - tolerate a missing cw2 entry (legacy / test fixtures), skipping
+///     the comparison rather than erroring
+///   - bump the cw2 record on success so subsequent migrates see the
+///     new version
+///
+/// `MigrateMsg::UpdateVersion {}` is the no-op variant — it exists so
+/// operators have an explicit "just bump the version, no other state
+/// changes" path. Future variants can carry parameters; the downgrade
+/// guard runs unconditionally first so they all benefit.
+pub fn migrate(
+    deps: DepsMut,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, ContractError> {
+    if let Ok(stored_version) = cw2::get_contract_version(deps.storage) {
+        let stored_semver: semver::Version = stored_version.version.parse().map_err(|e: semver::Error| {
+            ContractError::StoredVersionInvalid {
+                version: stored_version.version.clone(),
+                msg: e.to_string(),
+            }
+        })?;
+        let current_semver: semver::Version = CONTRACT_VERSION.parse().map_err(|e: semver::Error| {
+            ContractError::CurrentVersionInvalid {
+                version: CONTRACT_VERSION.to_string(),
+                msg: e.to_string(),
+            }
+        })?;
+        if stored_semver > current_semver {
+            return Err(ContractError::DowngradeRefused {
+                stored: stored_semver.to_string(),
+                current: current_semver.to_string(),
+            });
+        }
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    match msg {
+        MigrateMsg::UpdateVersion {} => Ok(Response::new()
+            .add_attribute(attrs::ACTION, attrs::MIGRATE)
+            .add_attribute(attrs::VARIANT, attrs::MIGRATE_VARIANT_UPDATE_VERSION)
+            .add_attribute(attrs::CONTRACT_NAME, CONTRACT_NAME)
+            .add_attribute(attrs::CONTRACT_VERSION, CONTRACT_VERSION)),
+    }
+}

--- a/expand-economy/src/msg.rs
+++ b/expand-economy/src/msg.rs
@@ -1,5 +1,12 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
+/// Wire-compatible payload for the cross-contract `RequestExpansion`
+/// call from the factory. Owned by `pool_factory_interfaces` so the
+/// factory and this contract share one source of truth — wire-format
+/// changes here MUST be coordinated with the factory crate. If the
+/// upstream type is renamed, downstream JSON deserialization here will
+/// fail at runtime with an opaque error; pin against this re-export
+/// rather than re-implementing the shape.
 pub use pool_factory_interfaces::ExpandEconomyMsg;
 
 #[cw_serde]

--- a/expand-economy/src/state.rs
+++ b/expand-economy/src/state.rs
@@ -77,6 +77,11 @@ pub struct Config {
 }
 
 /// Persisted contract `Config` (factory address, owner, bluechip denom).
+///
+/// Set in `instantiate` and never removed. Handlers use `CONFIG.load`
+/// rather than `may_load` because the absence of a value would only
+/// mean the contract was never instantiated — a programmer-error
+/// condition rather than a domain failure.
 pub const CONFIG: Item<Config> = Item::new("config");
 
 /// Default `bluechip_denom` for `InstantiateMsg` when the field is omitted.
@@ -84,12 +89,20 @@ pub const CONFIG: Item<Config> = Item::new("config");
 /// anything unless the chain denom changes.
 pub const DEFAULT_BLUECHIP_DENOM: &str = "ubluechip";
 
+/// Pending withdrawal awaiting timelock expiry.
+///
+/// `recipient` is stored as `Addr` after `addr_validate` at propose time
+/// so the apply path doesn't have to re-validate. `unlocks_at` is the
+/// block time at-or-after which the withdrawal becomes executable;
+/// `serde(alias = "execute_after")` keeps records written by the
+/// pre-rename code path deserializing cleanly.
 #[cw_serde]
 pub struct PendingWithdrawal {
     pub amount: Uint128,
     pub denom: String,
-    pub recipient: String,
-    pub execute_after: Timestamp,
+    pub recipient: Addr,
+    #[serde(alias = "execute_after")]
+    pub unlocks_at: Timestamp,
 }
 
 /// Timelock between `ProposeWithdrawal` and `ExecuteWithdrawal` (48 hours).
@@ -99,16 +112,25 @@ pub const CONFIG_TIMELOCK_SECONDS: u64 = 172_800;
 /// Pending withdrawal awaiting timelock expiry.
 pub const PENDING_WITHDRAWAL: Item<PendingWithdrawal> = Item::new("pending_withdrawal");
 
+/// Pending config update awaiting timelock expiry.
+///
+/// Address fields are validated at propose time and stored as
+/// `Option<Addr>` so the apply path doesn't have to re-validate. The
+/// `unlocks_at` field uses `serde(alias = "effective_after")` so
+/// records written by the pre-rename code path deserialize cleanly.
 #[cw_serde]
 pub struct PendingConfigUpdate {
-    pub factory_address: Option<String>,
-    pub owner: Option<String>,
+    pub factory_address: Option<Addr>,
+    pub owner: Option<Addr>,
     /// If set, applied to `Config.bluechip_denom` when the timelock expires.
-    /// Unset means "don't change the denom". Stored as raw String — validated
-    /// at propose time, not at apply time, so an empty string fails early.
+    /// Unset means "don't change the denom". Validated at propose time
+    /// against the cosmos-sdk denom rules (length, leading char, allowed
+    /// inner chars) so an invalid string fails at propose rather than 48h
+    /// later at apply.
     #[serde(default)]
     pub bluechip_denom: Option<String>,
-    pub effective_after: Timestamp,
+    #[serde(alias = "effective_after")]
+    pub unlocks_at: Timestamp,
 }
 /// Pending config update awaiting timelock expiry.
 pub const PENDING_CONFIG_UPDATE: Item<PendingConfigUpdate> = Item::new("pending_config_update");

--- a/expand-economy/src/timelock.rs
+++ b/expand-economy/src/timelock.rs
@@ -1,0 +1,236 @@
+//! Owner-gated timelock flows for both `Config` updates and
+//! one-shot `Withdrawal`s. Each flow follows the same shape:
+//!   propose  → validate inputs, write pending, emit `unlocks_at`
+//!   execute  → load pending, require timelock expired, apply
+//!   cancel   → load pending, drop it
+//!
+//! The cancel arms share an `owner_gated_cancel` helper in
+//! `crate::helpers`; propose/apply have flow-specific bodies but use
+//! the same helpers (`load_config_as_owner`, `ensure_absent`,
+//! `load_or_err`, `require_timelock_expired`).
+
+use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, MessageInfo, Response, Uint128};
+
+use crate::attrs;
+use crate::denom::validate_native_denom;
+use crate::error::ContractError;
+use crate::helpers::{
+    ensure_absent, load_config_as_owner, load_or_err, owner_gated_cancel,
+    require_timelock_expired,
+};
+use crate::state::{
+    PendingConfigUpdate, PendingWithdrawal, CONFIG, CONFIG_TIMELOCK_SECONDS,
+    PENDING_CONFIG_UPDATE, PENDING_WITHDRAWAL, WITHDRAW_TIMELOCK_SECONDS,
+};
+
+// ---------------------------------------------------------------------------
+// Config update flow
+// ---------------------------------------------------------------------------
+
+pub fn execute_propose_config_update(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    factory_address: Option<String>,
+    owner: Option<String>,
+    bluechip_denom: Option<String>,
+) -> Result<Response, ContractError> {
+    load_config_as_owner(deps.storage, &info.sender)?;
+    ensure_absent(
+        deps.storage,
+        &PENDING_CONFIG_UPDATE,
+        ContractError::ConfigUpdateAlreadyPending,
+    )?;
+
+    // Validate inputs at propose time — invalid proposals fail here
+    // rather than 48h later at apply.
+    let validated_factory: Option<Addr> = factory_address
+        .as_deref()
+        .map(|a| deps.api.addr_validate(a))
+        .transpose()?;
+    let validated_owner: Option<Addr> = owner
+        .as_deref()
+        .map(|a| deps.api.addr_validate(a))
+        .transpose()?;
+    if let Some(d) = bluechip_denom.as_deref() {
+        // Full cosmos-sdk denom format validation at propose time.
+        // Operator typos surface 48h earlier than they otherwise would
+        // (when someone tries to apply and every subsequent
+        // `RequestExpansion` breaks).
+        validate_native_denom(d)?;
+    }
+
+    let unlocks_at = env.block.time.plus_seconds(CONFIG_TIMELOCK_SECONDS);
+
+    PENDING_CONFIG_UPDATE.save(
+        deps.storage,
+        &PendingConfigUpdate {
+            factory_address: validated_factory,
+            owner: validated_owner,
+            bluechip_denom,
+            unlocks_at,
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_attribute(attrs::ACTION, attrs::PROPOSE_CONFIG_UPDATE)
+        .add_attribute(attrs::UNLOCKS_AT, unlocks_at.to_string()))
+}
+
+pub fn execute_apply_config_update(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    let mut config = load_config_as_owner(deps.storage, &info.sender)?;
+    let pending = load_or_err(
+        deps.storage,
+        &PENDING_CONFIG_UPDATE,
+        ContractError::NoPendingConfigUpdateToExecute,
+    )?;
+
+    require_timelock_expired(env.block.time, pending.unlocks_at)?;
+
+    if let Some(factory) = pending.factory_address {
+        config.factory_address = factory;
+    }
+    if let Some(new_owner) = pending.owner {
+        config.owner = new_owner;
+    }
+    if let Some(new_denom) = pending.bluechip_denom {
+        // Denom format was already enforced at propose time; re-check
+        // here as defense-in-depth in case a future migration ever
+        // inserts a PendingConfigUpdate directly, bypassing propose.
+        // Cheap to repeat (no I/O), and locks the invariant on the
+        // apply path too.
+        validate_native_denom(&new_denom)?;
+        config.bluechip_denom = new_denom;
+    }
+
+    CONFIG.save(deps.storage, &config)?;
+    PENDING_CONFIG_UPDATE.remove(deps.storage);
+
+    Ok(Response::new()
+        .add_attribute(attrs::ACTION, attrs::EXECUTE_CONFIG_UPDATE)
+        .add_attribute(attrs::FACTORY, &config.factory_address)
+        .add_attribute(attrs::OWNER, &config.owner)
+        .add_attribute(attrs::BLUECHIP_DENOM, &config.bluechip_denom))
+}
+
+pub fn execute_cancel_config_update(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    owner_gated_cancel(
+        deps,
+        info,
+        &PENDING_CONFIG_UPDATE,
+        ContractError::NoPendingConfigUpdateToCancel,
+        attrs::CANCEL_CONFIG_UPDATE,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawal flow
+// ---------------------------------------------------------------------------
+
+pub fn execute_propose_withdrawal(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    amount: Uint128,
+    denom: String,
+    recipient: Option<String>,
+) -> Result<Response, ContractError> {
+    load_config_as_owner(deps.storage, &info.sender)?;
+    ensure_absent(
+        deps.storage,
+        &PENDING_WITHDRAWAL,
+        ContractError::WithdrawalAlreadyPending,
+    )?;
+
+    let target = recipient.unwrap_or_else(|| info.sender.to_string());
+    let target_addr = deps.api.addr_validate(&target)?;
+    validate_native_denom(&denom)?;
+
+    let unlocks_at = env.block.time.plus_seconds(WITHDRAW_TIMELOCK_SECONDS);
+    PENDING_WITHDRAWAL.save(
+        deps.storage,
+        &PendingWithdrawal {
+            amount,
+            denom: denom.clone(),
+            recipient: target_addr.clone(),
+            unlocks_at,
+        },
+    )?;
+
+    Ok(Response::new()
+        .add_attribute(attrs::ACTION, attrs::PROPOSE_WITHDRAWAL)
+        .add_attribute(attrs::RECIPIENT, &target_addr)
+        .add_attribute(attrs::AMOUNT, amount)
+        .add_attribute(attrs::DENOM, denom)
+        .add_attribute(attrs::UNLOCKS_AT, unlocks_at.to_string()))
+}
+
+pub fn execute_withdrawal(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    load_config_as_owner(deps.storage, &info.sender)?;
+    let pending = load_or_err(
+        deps.storage,
+        &PENDING_WITHDRAWAL,
+        ContractError::NoPendingWithdrawalToExecute,
+    )?;
+
+    require_timelock_expired(env.block.time, pending.unlocks_at)?;
+
+    PENDING_WITHDRAWAL.remove(deps.storage);
+
+    // Clamp the requested amount to the contract's current balance so a
+    // proposed-but-stale withdrawal (e.g. balance drew down via
+    // RequestExpansion between propose and execute) doesn't fail the
+    // whole tx at the bank module. Transfer the smaller of (requested,
+    // balance) and emit both values so the caller can detect the clamp.
+    let balance = deps
+        .querier
+        .query_balance(&env.contract.address, &pending.denom)?;
+    let amount_to_send = pending.amount.min(balance.amount);
+
+    let mut response = Response::new()
+        .add_attribute(attrs::ACTION, attrs::EXECUTE_WITHDRAWAL)
+        .add_attribute(attrs::RECIPIENT, &pending.recipient)
+        .add_attribute(attrs::REQUESTED_AMOUNT, pending.amount)
+        .add_attribute(attrs::AMOUNT, amount_to_send)
+        .add_attribute(attrs::CONTRACT_BALANCE, balance.amount)
+        .add_attribute(attrs::DENOM, &pending.denom);
+
+    if !amount_to_send.is_zero() {
+        let send_msg = BankMsg::Send {
+            to_address: pending.recipient.into_string(),
+            amount: vec![Coin {
+                denom: pending.denom,
+                amount: amount_to_send,
+            }],
+        };
+        response = response.add_message(send_msg);
+    } else {
+        response = response.add_attribute(attrs::NOTE, attrs::NOTE_WITHDRAWAL_NO_FUNDS);
+    }
+
+    Ok(response)
+}
+
+pub fn execute_cancel_withdrawal(
+    deps: DepsMut,
+    info: MessageInfo,
+) -> Result<Response, ContractError> {
+    owner_gated_cancel(
+        deps,
+        info,
+        &PENDING_WITHDRAWAL,
+        ContractError::NoPendingWithdrawalToCancel,
+        attrs::CANCEL_WITHDRAWAL,
+    )
+}


### PR DESCRIPTION
HIGH:
- Replace `Std(StdError::generic_err(...))` with typed ContractError variants for every domain failure: RecipientRateLimited, TimelockNotExpired, BluechipDenomMismatch, FactoryQueryFailed, ConfigUpdateAlreadyPending, WithdrawalAlreadyPending, NoPendingConfigUpdateTo{Execute,Cancel}, NoPendingWithdrawalTo{Execute,Cancel}, InvalidDenom { denom, reason: InvalidDenomReason }, DowngradeRefused, StoredVersionInvalid, CurrentVersionInvalid.
- Add `owner_gated_cancel<T>` helper in `helpers.rs` and route both CancelConfigUpdate and CancelWithdrawal through it. The load_config_as_owner -> load_or_err -> remove -> Response shape now exists in exactly one place.
- Split contract.rs (758 lines) into focused submodules:
    contract.rs     — entry points + dispatch (~145 lines)
    helpers.rs      — owner-gating + storage helpers + owner_gated_cancel
                      + require_timelock_expired
    denom.rs        — validate_native_denom (typed InvalidDenom)
    factory_query.rs — wire types + cross_validate_factory_denom
    expand.rs       — execute_expand_economy + 8 phase helpers
    timelock.rs     — propose/apply/cancel for both config + withdrawal
    migrate.rs      — migrate handler + downgrade guard
    attrs.rs        — every attribute key + action value as `pub const`
- Decompose execute_expand_economy from one 190-line function into a
  ~25-line dispatcher plus 8 named phase helpers
  (require_factory_caller, dormant_response, enforce_recipient_rate_limit,
  check_and_compute_window, maybe_skip_for_balance, persist_expansion_state,
  payout_response). Phase ordering documented at the file top.

MEDIUM:
- Standardize entry-point Result types on Result<_, ContractError> across instantiate, execute, query, and migrate. Added a `map_std` helper in contract.rs to convert the StdError that `to_json_binary` returns.
- Unify `effective_after` (PendingConfigUpdate) and `execute_after` (PendingWithdrawal) into one `unlocks_at` field name on both structs. Wire-format compatibility via `#[serde(alias = "effective_after")]` / `#[serde(alias = "execute_after")]` so records written by the pre-rename code path still deserialize. Attribute emission is now `attrs::UNLOCKS_AT` for both flows so off-chain indexers can use one parser.
- `require_timelock_expired(now, ready_at)` helper replaces the two duplicated "Timelock not expired" generic_err sites.
- Centralize every attribute key + action value in attrs.rs as `pub const`. Every Response::add_attribute site references the constant.
- Document the `CONFIG.load`-vs-may_load convention on the CONFIG Item itself ("Set in instantiate and never removed").
- Tighten storage types: PendingWithdrawal.recipient is now Addr (validated at propose); PendingConfigUpdate.factory_address / .owner are now Option<Addr> (validated at propose). Wire-format unchanged because Addr serializes as String.
- Replace `.expect("checked length >= 3")` in validate_native_denom with let-else returning a typed error variant.
- query_balance call sites now consistently use `&env.contract.address` (Addr-by-reference).

LOW:
- Doc-comment on `pub use pool_factory_interfaces::ExpandEconomyMsg` noting the cross-crate wire-format dependency.
- Format strings in the typed error variants use captured identifiers via thiserror's `#[error]` (the only `format!` sites were in error construction, all moved into typed variants).
- CONTRACT_NAME / CONTRACT_VERSION lifted to `pub const` in lib.rs; contract.rs and migrate.rs both reference them.
- validate_native_denom returns ContractError::InvalidDenom { reason: ... } with a typed InvalidDenomReason enum (length / leading-char / disallowed-char) — clients can match structurally.

Tests: 34 passing, 0 failing — all pre-existing assertions still hold (they only checked error-message substrings and field semantics that are preserved by the typed variants and serde aliases).

https://claude.ai/code/session_01AoDpqQ13KHfT4u3HuXMtK1