### PR TITLE
docs+frontend: sync README and reference UI with current contract sur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Bluechip is a DeFi protocol that enables content creators to launch their own to
 
 ## Architecture
 
-The protocol is organized as four contracts and two shared library packages:
+The protocol is organized as four core production contracts (factory, creator-pool, standard-pool, expand-economy), one auxiliary contract (router for multi-hop swaps), one test-only contract (mockoracle), and three shared library packages (pool-core, pool-factory-interfaces, easy-addr). The diagram below covers the four production contracts:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -102,26 +102,16 @@ Both pool kinds share the same liquidity/swap/position logic via `pool-core`, th
 
 ### Creating a Creator Pool
 
-Creators can launch their own token pool by calling the factory contract. This is the original commit-phase flow.
+Creators launch their own token pool by calling the factory's `Create`. Only the pair shape and the new CW20 metadata are caller-supplied; every other knob (commit threshold, fee splits, threshold payout, lock caps, oracle config) is read from factory config at the time of the call. The CW20 contract address is filled in by the factory during the reply chain.
 
 ```json
 {
   "create": {
-    "pair_msg": {
-      "asset_infos": [
-        { "native_token": { "denom": "bluechip" } },
-        { "token": { "contract_addr": "CREATED_BY_FACTORY" } }
-      ],
-      "token_code_id": 1,
-      "factory_addr": "factory_contract_address",
-      "fee_info": {
-        "bluechip_address": "protocol_wallet",
-        "creator_address": "creator_wallet",
-        "bluechip_fee": "0.01",
-        "creator_fee": "0.05"
-      },
-      "commit_limit_usd": "25000000000",
-      "oracle_addr": "pyth_oracle_address"
+    "pool_msg": {
+      "pool_token_info": [
+        { "bluechip": { "denom": "ubluechip" } },
+        { "creator_token": { "contract_addr": "WILL_BE_CREATED_BY_FACTORY" } }
+      ]
     },
     "token_info": {
       "name": "Creator Token Name",
@@ -135,7 +125,7 @@ Creators can launch their own token pool by calling the factory contract. This i
 Each creator pool receives:
 - A unique CW20 token for the creator (mint cap: 1,500,000)
 - A CW721 NFT contract for liquidity positions
-- Configurable fee structure (default: 1% protocol + 5% creator)
+- Factory-configured fee structure (default: 1% protocol + 5% creator)
 - Bluechip tokens minted via the Expand Economy contract on threshold-crossing (up to 500 per pool, decreasing over time)
 
 A per-address rate limit (1 hour) on `Create` calls keeps an attacker from cheaply inflating the commit-pool ordinal that drives the expand-economy decay schedule.
@@ -147,9 +137,9 @@ Anyone can create a plain xyk pool around two pre-existing assets via `CreateSta
 ```json
 {
   "create_standard_pool": {
-    "asset_infos": [
-      { "native_token": { "denom": "ubluechip" } },
-      { "token": { "contract_addr": "cosmos1..." } }
+    "pool_token_info": [
+      { "bluechip": { "denom": "ubluechip" } },
+      { "creator_token": { "contract_addr": "cosmos1..." } }
     ],
     "label": "ubluechip-MYTOKEN-xyk"
   }
@@ -285,10 +275,12 @@ The first depositor on an empty pool has `MINIMUM_LIQUIDITY = 1000` LP units loc
 
 ```json
 {
-  "add_liquidity": {
+  "deposit_liquidity": {
     "amount0": "1000000",
     "amount1": "1000000",
-    "min_liquidity": "900000"
+    "min_amount0": "990000",
+    "min_amount1": "990000",
+    "transaction_deadline": null
   }
 }
 ```
@@ -333,14 +325,18 @@ Small positions are subject to a fee-size multiplier; the clipped portion is rou
 
 ```json
 {
-  "remove_liquidity": {
+  "remove_partial_liquidity": {
     "position_id": "123",
-    "liquidity_amount": "500000"
+    "liquidity_to_remove": "500000",
+    "min_amount0": null,
+    "min_amount1": null,
+    "max_ratio_deviation_bps": 100,
+    "transaction_deadline": null
   }
 }
 ```
 
-Partial removal keeps the NFT; full removal burns it. Pulling reserves below `MINIMUM_LIQUIDITY` auto-pauses the pool (separate auto-pause flag); the pause clears automatically as soon as a deposit restores reserves above the floor.
+`RemovePartialLiquidityByPercent { percentage }` and `RemoveAllLiquidity {}` are convenience variants over the same handler. Partial removal keeps the NFT; full removal burns it. Pulling reserves below `MINIMUM_LIQUIDITY` auto-pauses the pool (separate auto-pause flag); the pause clears automatically as soon as a deposit restores reserves above the floor.
 
 ---
 
@@ -401,67 +397,50 @@ Bluechip uses an internal oracle to price the native bluechip token in USD.
 
 ## Query Endpoints
 
-### Pool State
+### Pool State (LP-side)
 
 ```json
 {
-  "get_pool_state": {}
+  "pool_state": {}
 }
 ```
 
-**Returns:**
-```json
-{
-  "reserve0": "1000000000",
-  "reserve1": "5000000000",
-  "total_liquidity": "2000000000",
-  "is_threshold_hit": true
-}
-```
-
-Standard pools return `is_threshold_hit: true` from instantiate (no commit phase).
+**Returns** `PoolStateResponse`: `nft_ownership_accepted`, `reserve0`, `reserve1`, `total_liquidity`, `block_time_last`. The factory-facing `get_pool_state {}` returns a different (richer) shape, `PoolStateResponseForFactory`; LP / SDK consumers should use `pool_state {}`.
 
 ### Commit Status
 
 ```json
 {
-  "get_commit_status": {}
+  "is_fully_commited": {}
 }
 ```
 
-**Returns:**
-```json
-{
-  "total_usd_raised": "25000000000",
-  "threshold": "25000000000",
-  "is_active": true
-}
-```
-
-(Creator-pool only — standard pools surface `FullyCommitted` with zeros.)
+**Returns** the on-chain `CommitStatus` enum: either the bare string `"fully_committed"` or `{ "in_progress": { "raised": "...", "target": "25000000000" } }`. Standard pools always return `"fully_committed"` (no commit phase).
 
 ### Position Info
 
 ```json
 {
-  "get_position": {
-    "position_id": "123"
-  }
+  "position": { "position_id": "123" }
 }
 ```
+
+`positions { start_after, limit }` and `positions_by_owner { owner, start_after, limit }` page through the same shape.
 
 ### Simulate Swap
 
 ```json
 {
-  "simulate_swap": {
+  "simulation": {
     "offer_asset": {
-      "native_token": { "denom": "bluechip" }
-    },
-    "offer_amount": "1000000"
+      "info": { "bluechip": { "denom": "ubluechip" } },
+      "amount": "1000000"
+    }
   }
 }
 ```
+
+`reverse_simulation { ask_asset }` solves for the offer amount that produces a given output.
 
 ### Pool Analytics
 
@@ -537,11 +516,11 @@ The standard-pool reply handler will reject the transaction if the CW20 has a tr
 
 ```json
 {
-  "get_commit_info": {
-    "address": "bluechip1..."
-  }
+  "committing_info": { "wallet": "bluechip1..." }
 }
 ```
+
+`last_commited { wallet }` (note the on-chain typo) returns the wallet's most recent commit timestamp and per-commit USD / bluechip amounts; useful for enforcing the 13-second per-wallet rate limit client-side before broadcasting. `pool_commits { pool_contract_address, min_payment_usd, after_timestamp, start_after, limit }` pages the full committer ledger for a pool — the response carries `committers` and a `page_count` (size of THIS page after filtering, not the pre-filter total).
 
 ---
 
@@ -936,12 +915,19 @@ bluechip-contracts/
 ├── creator-pool/                     # Creator pool (commit + AMM)
 ├── standard-pool/                    # Plain xyk pool
 ├── expand-economy/                   # Bluechip mint reservoir
+├── mockoracle/                       # Test-only Pyth-shaped oracle
+├── router/                           # Multi-hop swap router
 ├── packages/
 │   ├── pool-core/                    # Shared AMM library
-│   └── pool-factory-interfaces/      # Shared wire-format types
+│   ├── pool-factory-interfaces/      # Shared wire-format types
+│   └── easy-addr/                    # Test-only deterministic-addr helper
+├── fuzz/                             # cargo-fuzz pure-math targets (excluded from default workspace)
+├── fuzz-stateful/                    # proptest stateful harness (workspace member)
 ├── keepers/                          # Off-chain bots (oracle / distribution)
 └── frontend/                         # Reference UI
 ```
+
+See `FUZZING.md` for the fuzz harness layout and `FUZZ_REVIEW.md` for the latest coverage audit.
 
 ### Deployment Order
 
@@ -955,16 +941,15 @@ bluechip-contracts/
 8. Wait for the oracle warm-up gate to clear (6 successful TWAP rounds)
 9. Creators can now create commit pools; anyone can create additional standard pools
 
-### Mainnet Deployment
+### Local / Mock-Oracle Deployment
 
-To deploy to Bluechip Mainnet:
+The repo ships `deploy_full_stack_mock_oracle.sh`, which uploads every wasm in this workspace plus the bundled `cw20_base.wasm` / `cw721_base.wasm` and the mock oracle, instantiates them in the correct order, and bootstraps the ATOM/bluechip anchor pool. Edit the configurable section at the top of the script (chain, gas prices, wallet keys) before running:
 
-1. Configure your wallet (ensure you have `bluechipd` CLI tool)
-2. Run the deployment script:
-   ```bash
-   ./deploy_mainnet.sh
-   ```
-3. Update specific configurations in `deploy_mainnet.sh` (Oracle address, Price Feed ID, expand-economy denom) if necessary.
+```bash
+./deploy_full_stack_mock_oracle.sh
+```
+
+Mainnet deployment runs the same sequence but against a real Pyth oracle address — there is no checked-in `deploy_mainnet.sh`; clone the mock-oracle script, swap the oracle/feed IDs, and remove the mock-oracle upload step.
 
 ---
 

--- a/frontend/src/components/CommitTracker.tsx
+++ b/frontend/src/components/CommitTracker.tsx
@@ -10,7 +10,7 @@ interface CommitTrackerProps {
 }
 
 interface CommitData {
-    last_commited: string;
+    last_committed: string;
     total_paid_usd: string;
     total_paid_bluechip: string;
 }
@@ -48,14 +48,14 @@ const CommitTracker: React.FC<CommitTrackerProps> = ({ client, address, contract
                 }
             });
 
-            if (response && response.commiters) {
-                const sortedCommits = [...response.commiters].sort((a, b) => {
-                    return parseInt(a.last_commited) - parseInt(b.last_commited);
+            if (response && response.committers) {
+                const sortedCommits = [...response.committers].sort((a, b) => {
+                    return parseInt(a.last_committed) - parseInt(b.last_committed);
                 });
 
                 let cumulative = 0;
                 let bluechipTotal = 0;
-                const data = sortedCommits.map((commit, index) => {
+                const data = sortedCommits.map((commit) => {
                     const value = parseInt(commit.total_paid_usd);
                     const bluechipValue = parseInt(commit.total_paid_bluechip);
                     cumulative += value;
@@ -65,7 +65,7 @@ const CommitTracker: React.FC<CommitTrackerProps> = ({ client, address, contract
                         name: ``,
                         value: value,
                         total: cumulative,
-                        timestamp: new Date(parseInt(commit.last_commited) / 1000000).toLocaleString()
+                        timestamp: new Date(parseInt(commit.last_committed) / 1000000).toLocaleString()
                     };
                 });
 

--- a/frontend/src/components/CreatePool.tsx
+++ b/frontend/src/components/CreatePool.tsx
@@ -1,11 +1,14 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Card, CardContent, Typography, TextField, Button, Box, Alert, IconButton, Tooltip } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { DEFAULT_CHAIN_CONFIG } from '../types/FrontendTypes';
 
-// Factory contract address - configured during deployment. Will need to make dynamic
-const FACTORY_ADDRESS = import.meta.env.VITE_FACTORY_ADDRESS || 'cosmos1yvgh8xeju5dyr0zxlkvq09htvhjj20fncp5g58np4u25g8rkpgjst8ghg8';
+// Factory contract address - configured during deployment.
+const FACTORY_ADDRESS =
+    import.meta.env.VITE_FACTORY_ADDRESS ||
+    'cosmos1yvgh8xeju5dyr0zxlkvq09htvhjj20fncp5g58np4u25g8rkpgjst8ghg8';
+
 interface CreatePoolProps {
     client: SigningCosmWasmClient | null;
     address: string;
@@ -15,39 +18,15 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
     const [tokenName, setTokenName] = useState('');
     const [tokenSymbol, setTokenSymbol] = useState('');
     const [isStandardPool, setIsStandardPool] = useState(false);
+    const [standardPairAddress, setStandardPairAddress] = useState('');
+    const [standardPoolLabel, setStandardPoolLabel] = useState('');
     const [status, setStatus] = useState('');
     const [txHash, setTxHash] = useState('');
     const [copySuccess, setCopySuccess] = useState(false);
 
-    // Default configuration values based on factory settings
-    const DEFAULT_CONFIG = {
-        commitThresholdUsd: '25000000000', // $25,000 in micro-units
-        commitAmountForThreshold: '25000000000',
-        maxBluechipLock: '10000000000',
-        creatorExcessLockDays: 7,
-        cw20CodeId: 1,
-        decimal: 6,
-        // Threshold payout distribution (must sum to total mint)
-        thresholdPayout: {
-            creator_reward_amount: '325000000000',
-            bluechip_reward_amount: '25000000000',
-            pool_seed_amount: '350000000000',
-            commit_return_amount: '500000000000'
-        },
-        commitFeeInfo: {
-            commit_fee_bluechip: '0.01', // 1%
-            commit_fee_creator: '0.05'   // 5%
-        }
-    };
-
     const handleCreatePool = async () => {
         if (!client || !address) {
             setStatus('Please connect your wallet');
-            return;
-        }
-
-        if (!tokenName || !tokenSymbol) {
-            setStatus('Error: Please enter both token name and symbol');
             return;
         }
 
@@ -56,68 +35,73 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
             setTxHash('');
             setCopySuccess(false);
 
-            // Encode threshold payout to base64
-            const thresholdPayoutJson = JSON.stringify(DEFAULT_CONFIG.thresholdPayout);
-            const thresholdPayoutB64 = btoa(thresholdPayoutJson);
+            let createMsg: Record<string, unknown>;
+            let gas = '2000000';
 
-            // Build the Create message for the factory
-            const createMsg = {
-                create: {
-                    pool_msg: {
+            if (isStandardPool) {
+                if (!standardPairAddress) {
+                    setStatus('Error: Standard pool requires a CW20 pair address');
+                    return;
+                }
+                // CreateStandardPool { pool_token_info, label }. Caller pays the
+                // factory's standard_pool_creation_fee_usd in ubluechip; the
+                // factory converts USD -> bluechip via the internal oracle.
+                createMsg = {
+                    create_standard_pool: {
                         pool_token_info: [
                             { bluechip: { denom: DEFAULT_CHAIN_CONFIG.nativeDenom } },
-                            { creator_token: { contract_addr: 'WILL_BE_CREATED_BY_FACTORY' } }
+                            { creator_token: { contract_addr: standardPairAddress } },
                         ],
-                        cw20_token_contract_id: DEFAULT_CONFIG.cw20CodeId,
-                        factory_to_create_pool_addr: FACTORY_ADDRESS,
-                        threshold_payout: thresholdPayoutB64,
-                        commit_fee_info: {
-                            bluechip_wallet_address: address, // Use connected wallet
-                            creator_wallet_address: address,   // Use connected wallet
-                            commit_fee_bluechip: DEFAULT_CONFIG.commitFeeInfo.commit_fee_bluechip,
-                            commit_fee_creator: DEFAULT_CONFIG.commitFeeInfo.commit_fee_creator
-                        },
-                        creator_token_address: address, // Placeholder, will be set by factory
-                        commit_amount_for_threshold: DEFAULT_CONFIG.commitAmountForThreshold,
-                        commit_limit_usd: DEFAULT_CONFIG.commitThresholdUsd,
-                        // Schema requires these strings but the factory ignores them and
-                        // uses its own stored pyth config (set at factory instantiation).
-                        pyth_contract_addr_for_conversions: '',
-                        pyth_atom_usd_price_feed_id: '',
-                        max_bluechip_lock_per_pool: DEFAULT_CONFIG.maxBluechipLock,
-                        creator_excess_liquidity_lock_days: DEFAULT_CONFIG.creatorExcessLockDays,
-                        is_standard_pool: isStandardPool
+                        label:
+                            standardPoolLabel ||
+                            `${DEFAULT_CHAIN_CONFIG.nativeDenom}-${tokenSymbol || 'XYK'}-xyk`,
                     },
-                    token_info: {
-                        name: tokenName,
-                        symbol: tokenSymbol,
-                        decimal: DEFAULT_CONFIG.decimal
-                    }
+                };
+            } else {
+                if (!tokenName || !tokenSymbol) {
+                    setStatus('Error: Creator pools require a token name and symbol');
+                    return;
                 }
-            };
+                // Create { pool_msg, token_info }. Only `pool_token_info` and the
+                // CW20 metadata are caller-supplied; commit threshold, fee splits,
+                // threshold-payout amounts, lock caps, and oracle config are read
+                // from factory config.
+                createMsg = {
+                    create: {
+                        pool_msg: {
+                            pool_token_info: [
+                                { bluechip: { denom: DEFAULT_CHAIN_CONFIG.nativeDenom } },
+                                { creator_token: { contract_addr: 'WILL_BE_CREATED_BY_FACTORY' } },
+                            ],
+                        },
+                        token_info: {
+                            name: tokenName,
+                            symbol: tokenSymbol,
+                            // Pool enforces 6 decimals to match hardcoded payout amounts.
+                            decimal: 6,
+                        },
+                    },
+                };
+            }
 
             console.log('Creating pool with message:', JSON.stringify(createMsg, null, 2));
 
-            // Execute the Create message on the factory contract
             const result = await client.execute(
                 address,
                 FACTORY_ADDRESS,
                 createMsg,
-                {
-                    amount: [],
-                    gas: '2000000' // Higher gas limit for pool creation
-                },
-                'Create Pool'
+                { amount: [], gas },
+                isStandardPool ? 'CreateStandardPool' : 'Create',
             );
 
             console.log('Transaction Hash:', result.transactionHash);
             setTxHash(result.transactionHash);
             setStatus('Success! Pool creation transaction submitted.');
 
-            // Clear form on success
             setTokenName('');
             setTokenSymbol('');
-            setIsStandardPool(false);
+            setStandardPairAddress('');
+            setStandardPoolLabel('');
         } catch (err) {
             console.error('Full error:', err);
             setStatus('Error: ' + (err as Error).message);
@@ -136,29 +120,10 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
             <CardContent>
                 <Typography variant="h6" gutterBottom>Create Pool</Typography>
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                    Create a new creator pool with your custom token
+                    Creator pools start in commit phase and mint a fresh CW20. Standard pools wrap two pre-existing assets and are immediately tradeable.
                 </Typography>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                    <TextField
-                        label="Token Name"
-                        value={tokenName}
-                        onChange={(e) => setTokenName(e.target.value)}
-                        placeholder="My Creator Token"
-                        helperText="Full name of your token"
-                        required
-                    />
-
-                    <TextField
-                        label="Token Symbol (Ticker)"
-                        value={tokenSymbol}
-                        onChange={(e) => setTokenSymbol(e.target.value.toUpperCase())}
-                        placeholder="MCT"
-                        helperText="Short ticker symbol (e.g., BTC, ETH)"
-                        required
-                        inputProps={{ maxLength: 10 }}
-                    />
-
                     <Box sx={{
                         p: 2,
                         border: '1px solid',
@@ -166,12 +131,12 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
                         borderRadius: 1,
                         bgcolor: isStandardPool ? 'primary.50' : 'background.paper',
                         cursor: 'pointer',
-                        transition: 'all 0.2s ease'
+                        transition: 'all 0.2s ease',
                     }}
                         onClick={() => setIsStandardPool(!isStandardPool)}
                     >
                         <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-                            <div className={`checkbox ${isStandardPool ? 'checked' : ''}`} style={{
+                            <div style={{
                                 width: 20,
                                 height: 20,
                                 borderRadius: 4,
@@ -182,33 +147,90 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
                                 justifyContent: 'center',
                                 backgroundColor: isStandardPool ? '#1976d2' : 'transparent',
                             }}>
-                                {isStandardPool && <span style={{ color: 'white', fontSize: 14 }}>✓</span>}
+                                {isStandardPool && <span style={{ color: 'white', fontSize: 14 }}>OK</span>}
                             </div>
                             <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
-                                Create as Standard Pool
+                                Create as Standard Pool (xyk)
                             </Typography>
                         </Box>
                         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', ml: 4 }}>
-                            Skips the commit phase. Pool starts immediate with 0 liquidity. You must manually deposit liquidity to set the initial price.
+                            Permissionless. Wraps an existing CW20 paired against bluechip. Caller pays the factory&#39;s USD-denominated creation fee in ubluechip. Skips commit phase and the threshold-payout mint.
                         </Typography>
                     </Box>
 
-                    <Box sx={{ p: 2, bgcolor: 'info.light', borderRadius: 1 }}>
-                        <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
-                            Pool Configuration (Pre-set)
-                        </Typography>
-                        <Typography variant="body2">• Commit Threshold: $25,000 USD</Typography>
-                        <Typography variant="body2">• Commit Fee: 1% BlueChip, 5% Creator</Typography>
-                        <Typography variant="body2">• Max BlueChip Lock: 10,000 tokens</Typography>
-                        <Typography variant="body2">• Liquidity Lock: 7 days</Typography>
-                    </Box>
+                    {!isStandardPool && (
+                        <>
+                            <TextField
+                                label="Token Name"
+                                value={tokenName}
+                                onChange={(e) => setTokenName(e.target.value)}
+                                placeholder="My Creator Token"
+                                helperText="Full name of the new CW20 the factory will mint"
+                                required
+                            />
+                            <TextField
+                                label="Token Symbol (Ticker)"
+                                value={tokenSymbol}
+                                onChange={(e) => setTokenSymbol(e.target.value.toUpperCase())}
+                                placeholder="MCT"
+                                helperText="Short ticker symbol (e.g. BTC, ETH)"
+                                required
+                                inputProps={{ maxLength: 10 }}
+                            />
+                            <Box sx={{ p: 2, bgcolor: 'info.light', borderRadius: 1 }}>
+                                <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                                    Factory-Configured (read at call time)
+                                </Typography>
+                                <Typography variant="body2">- Commit threshold (USD)</Typography>
+                                <Typography variant="body2">- Commit fee splits (bluechip / creator)</Typography>
+                                <Typography variant="body2">- Threshold-payout amounts (creator / bluechip / pool seed / committers)</Typography>
+                                <Typography variant="body2">- Max bluechip lock per pool & creator excess lock days</Typography>
+                                <Typography variant="body2">- Pyth oracle address & price feed id</Typography>
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                                    The frontend no longer forwards these — the factory consults its own stored config. Per-address create cooldown: 1h.
+                                </Typography>
+                            </Box>
+                        </>
+                    )}
+
+                    {isStandardPool && (
+                        <>
+                            <TextField
+                                label="CW20 Pair Address"
+                                value={standardPairAddress}
+                                onChange={(e) => setStandardPairAddress(e.target.value)}
+                                placeholder="cosmos1..."
+                                helperText="Pre-existing CW20 to pair against bluechip"
+                                required
+                            />
+                            <TextField
+                                label="Pool Label (optional)"
+                                value={standardPoolLabel}
+                                onChange={(e) => setStandardPoolLabel(e.target.value)}
+                                placeholder="ubluechip-MYTOKEN-xyk"
+                                helperText="On-chain label used by explorers"
+                            />
+                            <TextField
+                                label="Display Symbol (optional)"
+                                value={tokenSymbol}
+                                onChange={(e) => setTokenSymbol(e.target.value.toUpperCase())}
+                                placeholder="MYTOKEN"
+                                helperText="Used to auto-fill the label if you leave it blank"
+                                inputProps={{ maxLength: 10 }}
+                            />
+                        </>
+                    )}
 
                     <Button variant="contained"
                         color="primary"
                         onClick={handleCreatePool}
-                        disabled={!client || !address || !tokenName || !tokenSymbol}
+                        disabled={
+                            !client ||
+                            !address ||
+                            (isStandardPool ? !standardPairAddress : !tokenName || !tokenSymbol)
+                        }
                     >
-                        Create Pool
+                        {isStandardPool ? 'Create Standard Pool' : 'Create Creator Pool'}
                     </Button>
 
                     {status && (
@@ -223,7 +245,7 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
                             bgcolor: 'success.light',
                             borderRadius: 1,
                             border: '1px solid',
-                            borderColor: 'success.main'
+                            borderColor: 'success.main',
                         }}>
                             <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 'bold' }}>
                                 Transaction Hash:
@@ -235,39 +257,21 @@ const CreatePool = ({ client, address }: CreatePoolProps) => {
                                         fontFamily: 'monospace',
                                         wordBreak: 'break-all',
                                         flex: 1,
-                                        fontSize: '0.85rem'
+                                        fontSize: '0.85rem',
                                     }}
                                 >
                                     {txHash}
                                 </Typography>
-                                <Tooltip title={copySuccess ? "Copied!" : "Copy to clipboard"}>
+                                <Tooltip title={copySuccess ? 'Copied!' : 'Copy to clipboard'}>
                                     <IconButton
                                         size="small"
                                         onClick={handleCopyTxHash}
-                                        color={copySuccess ? "success" : "primary"}
+                                        color={copySuccess ? 'success' : 'primary'}
                                     >
                                         <ContentCopyIcon fontSize="small" />
                                     </IconButton>
                                 </Tooltip>
                             </Box>
-                            <Typography
-                                variant="caption"
-                                component="a"
-                                href={`https://www.mintscan.io/cosmwasm-testnet/tx/${txHash}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                sx={{
-                                    display: 'block',
-                                    mt: 1,
-                                    color: 'primary.dark',
-                                    textDecoration: 'underline',
-                                    '&:hover': {
-                                        color: 'primary.main'
-                                    }
-                                }}
-                            >
-                                View on Mintscan →
-                            </Typography>
                         </Box>
                     )}
                 </Box>

--- a/frontend/src/components/modals/BuyModal.tsx
+++ b/frontend/src/components/modals/BuyModal.tsx
@@ -15,7 +15,7 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CloseIcon from '@mui/icons-material/Close';
 import { coins } from '@cosmjs/stargate';
-import { DEFAULT_CHAIN_CONFIG, TokenModalProps, toMicroUnits } from '../../types/FrontendTypes';
+import { DEFAULT_CHAIN_CONFIG, TokenModalProps, toMicroUnits, getBluechipDenom } from '../../types/FrontendTypes';
 
 const BuyModal: React.FC<TokenModalProps> = ({
     open,
@@ -52,6 +52,11 @@ const BuyModal: React.FC<TokenModalProps> = ({
 
             const amountInMicroUnits = toMicroUnits(amount, DEFAULT_CHAIN_CONFIG.coinDecimals);
 
+            // Pool denom is configurable per-pool; read it from the pair query.
+            const pairInfo = await client.queryContractSmart(token.poolAddress, { pair: {} });
+            const bluechipDenom =
+                getBluechipDenom(pairInfo.asset_infos) ?? DEFAULT_CHAIN_CONFIG.nativeDenom;
+
             const deadlineInNs = deadline && parseFloat(deadline) > 0
                 ? (Date.now() + parseFloat(deadline) * 60 * 1000) * 1_000_000
                 : null;
@@ -59,7 +64,7 @@ const BuyModal: React.FC<TokenModalProps> = ({
             const msg = {
                 simple_swap: {
                     offer_asset: {
-                        info: { bluechip: { denom: DEFAULT_CHAIN_CONFIG.nativeDenom } },
+                        info: { bluechip: { denom: bluechipDenom } },
                         amount: amountInMicroUnits
                     },
                     belief_price: null,
@@ -69,7 +74,7 @@ const BuyModal: React.FC<TokenModalProps> = ({
                 }
             };
 
-            const funds = coins(amountInMicroUnits, DEFAULT_CHAIN_CONFIG.nativeDenom);
+            const funds = coins(amountInMicroUnits, bluechipDenom);
 
             const result = await client.execute(
                 address,

--- a/frontend/src/components/modals/CommitModal.tsx
+++ b/frontend/src/components/modals/CommitModal.tsx
@@ -14,7 +14,7 @@ import {
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CloseIcon from '@mui/icons-material/Close';
-import { TokenModalProps, toMicroUnits, DEFAULT_CHAIN_CONFIG } from '../../types/FrontendTypes';
+import { TokenModalProps, toMicroUnits, DEFAULT_CHAIN_CONFIG, getBluechipDenom } from '../../types/FrontendTypes';
 
 const CommitModal: React.FC<TokenModalProps> = ({
     open,
@@ -50,6 +50,13 @@ const CommitModal: React.FC<TokenModalProps> = ({
             }
 
             const amountInMicroUnits = toMicroUnits(amount, DEFAULT_CHAIN_CONFIG.coinDecimals);
+
+            // Pool denom is configurable per-pool; read it from the pool's pair
+            // query rather than assuming DEFAULT_CHAIN_CONFIG.nativeDenom.
+            const pairInfo = await client.queryContractSmart(token.poolAddress, { pair: {} });
+            const bluechipDenom =
+                getBluechipDenom(pairInfo.asset_infos) ?? DEFAULT_CHAIN_CONFIG.nativeDenom;
+
             const thresholdStatus = await client.queryContractSmart(token.poolAddress, {
                 is_fully_commited: {}
             });
@@ -60,7 +67,7 @@ const CommitModal: React.FC<TokenModalProps> = ({
 
             const commitMsg = {
                 asset: {
-                    info: { bluechip: { denom: DEFAULT_CHAIN_CONFIG.nativeDenom } },
+                    info: { bluechip: { denom: bluechipDenom } },
                     amount: amountInMicroUnits
                 },
                 transaction_deadline: deadlineInNs,
@@ -70,7 +77,7 @@ const CommitModal: React.FC<TokenModalProps> = ({
             };
 
             const msg = { commit: commitMsg };
-            const funds = [{ denom: DEFAULT_CHAIN_CONFIG.nativeDenom, amount: amountInMicroUnits }];
+            const funds = [{ denom: bluechipDenom, amount: amountInMicroUnits }];
 
             const result = await client.execute(
                 address,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,1 @@
-// <reference types="vite/client" />
+/// <reference types="vite/client" />


### PR DESCRIPTION
…face

README:
- Replace stale Create / CreateStandardPool JSON examples with the caller-supplied shapes the factory actually accepts (only pool_token_info + token_info; threshold/fee/payout/oracle config is read from factory state).
- Rewrite the liquidity / removal / query examples to match the on-chain method names (deposit_liquidity, remove_partial_liquidity, pool_state, is_fully_commited, position, simulation, committing_info, etc.).
- Update repository layout to include router, mockoracle, fuzz and fuzz-stateful, and rephrase the deployment section to point at the checked-in deploy_full_stack_mock_oracle.sh.

Frontend:
- Rewrite CreatePool to send the real Create / CreateStandardPool envelopes; standard pools now go through the dedicated factory message (label + pool_token_info) instead of a fictional is_standard_pool flag.
- Fix CommitTracker field-name typos (commiters/last_commited -> committers/last_committed) so the on-chain pool_commits response is parsed correctly.
- Make CommitModal/BuyModal read the bluechip denom from the pool's pair query instead of assuming DEFAULT_CHAIN_CONFIG.nativeDenom, matching the existing Commit.tsx behavior.
- Repair vite-env.d.ts triple-slash directive so import.meta.env types resolve.