### PR TITLE
Add slice 4-6 scripts: completes the testnet test plan

### DIFF
--- a/apply_oracle_eligibility.sh
+++ b/apply_oracle_eligibility.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# =====================================================================
+# apply_oracle_eligibility.sh — land the 48h timelocked flag flip
+# =====================================================================
+# Slice 4 entry point. Run this AFTER the 48h timelock proposed by
+# propose_oracle_eligibility.sh has expired.
+#
+# Subcommands:
+#   query    (default) Show pending entry + remaining time, plus the
+#            current value of COMMIT_POOLS_AUTO_ELIGIBLE in storage.
+#   apply    factory.ApplySetCommitPoolsAutoEligible (will revert if
+#            the timelock hasn't elapsed). Then immediately calls
+#            factory.RefreshOraclePoolSnapshot to rebuild the
+#            ELIGIBLE_POOL_SNAPSHOT against the new flag value.
+#   cancel   factory.CancelSetCommitPoolsAutoEligible (only works
+#            BEFORE the apply lands).
+#   refresh  factory.RefreshOraclePoolSnapshot only — useful between
+#            commit-pool creations to force the snapshot to pick up
+#            the new pools without waiting on the lazy 5-day refresh.
+#            Rate-limited on-chain to ~12h via
+#            ORACLE_REFRESH_RATE_LIMIT_BLOCKS so it can't be spammed.
+# =====================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/osmo_testnet.env"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_osmo_tx_helpers.sh"
+require_state
+
+MODE="${1:-query}"
+
+show_state() {
+    echo "=== pending_commit_auto_eligible (raw storage) ==="
+    PENDING="$(query_raw_storage "$FACTORY_ADDR" 'pending_commit_auto_eligible')"
+    if [ -n "$PENDING" ]; then
+        echo "$PENDING" | jq .
+        PROPOSED_AT_NS="$(echo "$PENDING" | jq -r '.proposed_at // empty')"
+        if [ -n "$PROPOSED_AT_NS" ]; then
+            EFFECTIVE_AFTER_S=$(( PROPOSED_AT_NS / 1000000000 + 86400 * 2 ))
+            NOW_S="$(date -u +%s)"
+            REMAINING=$(( EFFECTIVE_AFTER_S - NOW_S ))
+            echo ""
+            if [ "$REMAINING" -gt 0 ]; then
+                MIN=$(( REMAINING / 60 ))
+                echo "timelock remaining: ${REMAINING}s (~${MIN} min). apply will revert until elapsed."
+            else
+                echo "timelock ELAPSED — \`apply\` subcommand will succeed."
+            fi
+        fi
+    else
+        echo "(no pending entry. either nothing was proposed yet, or apply/cancel already ran.)"
+    fi
+    echo ""
+    echo "=== commit_pools_auto_eligible (current value) ==="
+    CURR="$(query_raw_storage "$FACTORY_ADDR" 'commit_pools_auto_eligible')"
+    if [ -n "$CURR" ]; then
+        echo "current value: $CURR"
+    else
+        echo "(unset — defaults to false on fresh instantiates)"
+    fi
+}
+
+case "$MODE" in
+    query)
+        show_state
+        ;;
+    apply)
+        echo "sending factory.ApplySetCommitPoolsAutoEligible ..."
+        APPLY_RESULT="$(submit_tx wasm execute "$FACTORY_ADDR" \
+            '{"apply_set_commit_pools_auto_eligible":{}}')"
+        echo "OK — tx $(echo "$APPLY_RESULT" | jq -r '.txhash')"
+        echo ""
+        echo "refreshing oracle pool snapshot (so the new flag takes"
+        echo "effect immediately rather than at next lazy refresh) ..."
+        REFRESH_RESULT="$(submit_tx wasm execute "$FACTORY_ADDR" \
+            '{"refresh_oracle_pool_snapshot":{}}')"
+        echo "OK — tx $(echo "$REFRESH_RESULT" | jq -r '.txhash')"
+        echo ""
+        show_state
+        ;;
+    cancel)
+        echo "sending factory.CancelSetCommitPoolsAutoEligible ..."
+        RESULT="$(submit_tx wasm execute "$FACTORY_ADDR" \
+            '{"cancel_set_commit_pools_auto_eligible":{}}')"
+        echo "OK — tx $(echo "$RESULT" | jq -r '.txhash')"
+        echo ""
+        show_state
+        ;;
+    refresh)
+        echo "sending factory.RefreshOraclePoolSnapshot ..."
+        RESULT="$(submit_tx wasm execute "$FACTORY_ADDR" \
+            '{"refresh_oracle_pool_snapshot":{}}')"
+        echo "OK — tx $(echo "$RESULT" | jq -r '.txhash')"
+        ;;
+    *)
+        echo "usage: $0 [query | apply | cancel | refresh]" >&2
+        exit 1
+        ;;
+esac

--- a/create_commit_pool.sh
+++ b/create_commit_pool.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# =====================================================================
+# create_commit_pool.sh — spin up a commit (creator) pool via factory
+# =====================================================================
+# usage: bash create_commit_pool.sh <name> <symbol>
+#
+#   <name>   3–50 printable ASCII chars  (e.g. "Alpha Creator")
+#   <symbol> 3–12 chars A-Z + 0-9, must contain at least one letter
+#            (e.g. "ALPHA")
+#
+# Sends factory.Create with the post-cleanup CreatePool shape — only
+# pool_token_info + token_info; everything else (commit threshold,
+# fees, threshold-payout amounts, lock caps, oracle config) is read
+# from the factory's stored config and silently overwrites any
+# caller-supplied value.
+#
+# Pays the per-pool creation fee in BLUECHIP_DENOM. Currently sized at
+# STANDARD_POOL_FEE_FUNDS_BLUECHIP (200 BC, 2x the bootstrap fallback)
+# — same value used for the standard-pool create in slice 2.
+#
+# Per-address rate limit (state.rs:COMMIT_POOL_CREATE_RATE_LIMIT_SECONDS
+# = 3600s): the same address can only create one commit pool per hour.
+# To create multiple in close succession, fund a second key, switch
+# FROM in osmo_testnet.env, and re-run.
+#
+# Side effects:
+#   - Appends one line per created pool to commit_pools.txt:
+#       <pool_id>\t<pool_addr>\t<creator_token_addr>\t<symbol>
+#     This file is the source of truth for downstream slices that need
+#     to iterate over the test commit pools (cross_threshold.sh,
+#     test_rotation.sh, test_swing.sh).
+#   - Prints the addresses to stdout so the operator can paste them
+#     into the next command.
+# =====================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/osmo_testnet.env"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_osmo_tx_helpers.sh"
+require_state
+
+NAME="${1:-}"
+SYMBOL="${2:-}"
+if [ -z "$NAME" ] || [ -z "$SYMBOL" ]; then
+    echo "usage: $0 <name> <symbol>" >&2
+    echo "  example: $0 'Alpha Creator' ALPHA" >&2
+    exit 1
+fi
+
+# Client-side validation matching factory's validate_creator_token_info.
+# Catches obvious mistakes before burning a tx.
+NAME_LEN="${#NAME}"
+if [ "$NAME_LEN" -lt 3 ] || [ "$NAME_LEN" -gt 50 ]; then
+    echo "error: name must be 3–50 printable ASCII chars (got $NAME_LEN)" >&2
+    exit 1
+fi
+if ! [[ "$SYMBOL" =~ ^[A-Z0-9]{3,12}$ ]]; then
+    echo "error: symbol must be 3–12 chars matching ^[A-Z0-9]+$ (got '$SYMBOL')" >&2
+    exit 1
+fi
+if ! [[ "$SYMBOL" =~ [A-Z] ]]; then
+    echo "error: symbol must contain at least one A-Z letter (got '$SYMBOL')" >&2
+    exit 1
+fi
+
+echo "creating commit pool: name='$NAME' symbol='$SYMBOL'"
+echo "factory:    $FACTORY_ADDR"
+echo "creator:    $ADMIN_ADDR"
+echo ""
+
+CREATE_MSG="$(jq -nc \
+    --arg blue   "$BLUECHIP_DENOM" \
+    --arg name   "$NAME" \
+    --arg symbol "$SYMBOL" \
+    '{create:{
+        pool_msg:{
+            pool_token_info:[
+                {bluechip:{denom:$blue}},
+                {creator_token:{contract_addr:"WILL_BE_CREATED_BY_FACTORY"}}
+            ]
+        },
+        token_info:{
+            name:$name,
+            symbol:$symbol,
+            decimal:6
+        }
+    }}')"
+
+CREATE_RESULT="$(submit_tx wasm execute "$FACTORY_ADDR" "$CREATE_MSG" \
+    --amount "${STANDARD_POOL_FEE_FUNDS_BLUECHIP}${BLUECHIP_DENOM}")"
+
+POOL_ID="$(extract_attr "$CREATE_RESULT" wasm pool_id)"
+if [ -z "$POOL_ID" ] || [ "$POOL_ID" = "null" ]; then
+    echo "error: could not extract pool_id from create tx" >&2
+    echo "$CREATE_RESULT" | jq '.events[] | select(.type=="wasm" or .type=="create_pool")' >&2
+    exit 1
+fi
+echo "pool_id:        $POOL_ID"
+
+# Resolve pool address: filter the tx's instantiate events for the one
+# whose code_id matches CREATOR_POOL_CODE_ID. The CW20 (creator token)
+# and CW721 (position NFT) instantiate events also appear in this tx;
+# we capture all three.
+POOL_ADDR="$(echo "$CREATE_RESULT" | jq -r --arg cid "$CREATOR_POOL_CODE_ID" '
+    .events[] | select(.type == "instantiate") |
+    (.attributes | from_entries) as $a |
+    select($a.code_id == $cid) | $a._contract_address
+' | head -n 1)"
+CREATOR_TOKEN_ADDR="$(echo "$CREATE_RESULT" | jq -r --arg cid "$CW20_CODE_ID" '
+    .events[] | select(.type == "instantiate") |
+    (.attributes | from_entries) as $a |
+    select($a.code_id == $cid) | $a._contract_address
+' | head -n 1)"
+NFT_ADDR="$(echo "$CREATE_RESULT" | jq -r --arg cid "$CW721_CODE_ID" '
+    .events[] | select(.type == "instantiate") |
+    (.attributes | from_entries) as $a |
+    select($a.code_id == $cid) | $a._contract_address
+' | head -n 1)"
+
+echo "pool address:   ${POOL_ADDR:-?}"
+echo "creator token:  ${CREATOR_TOKEN_ADDR:-?}"
+echo "position NFT:   ${NFT_ADDR:-?}"
+
+# Append to commit_pools.txt (TSV, one line per pool).
+LOG_FILE="$SCRIPT_DIR/commit_pools.txt"
+printf '%s\t%s\t%s\t%s\n' "$POOL_ID" "$POOL_ADDR" "$CREATOR_TOKEN_ADDR" "$SYMBOL" >> "$LOG_FILE"
+echo ""
+echo "appended entry to $LOG_FILE"
+
+echo ""
+echo "NEXT:"
+echo "  1. Cross the commit threshold:"
+echo "     bash $SCRIPT_DIR/cross_threshold.sh $POOL_ADDR"
+echo "  2. After threshold-cross, force a snapshot rebuild so the"
+echo "     new commit pool flows into the oracle's eligible set:"
+echo "     bash $SCRIPT_DIR/apply_oracle_eligibility.sh refresh"

--- a/cross_threshold.sh
+++ b/cross_threshold.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# =====================================================================
+# cross_threshold.sh — commit enough BLUECHIP into a commit pool to
+#                      cross the USD threshold and trigger payout +
+#                      threshold-mint event.
+# =====================================================================
+# usage: bash cross_threshold.sh <pool_addr> [bluechip-amount-micro]
+#
+#   <pool_addr>             The commit pool address to commit into.
+#                           Pass one of the addresses from
+#                           commit_pools.txt (column 2).
+#   [bluechip-amount-micro] Optional. Total BLUECHIP_DENOM to commit
+#                           in one tx, in micro-units (6 decimals).
+#                           Defaults to 60_000 BC = 60_000_000_000
+#                           micro — sized to comfortably exceed the
+#                           default $25_000 threshold across the
+#                           range of OSMO/USD spot prices the test
+#                           plan assumes (~$0.30–$1.00).
+#
+# How the threshold actually crosses on-chain:
+#   1. The factory's commit handler converts the attached BLUECHIP
+#      amount to USD via `bluechip_to_usd` (which reads the
+#      currently-published bluechip price from the internal oracle).
+#   2. Cumulative USD raised is compared against
+#      `commit_threshold_limit_usd` (set at factory instantiate;
+#      $25_000 by default, see osmo_testnet.env).
+#   3. The first commit that crosses the threshold triggers
+#      `trigger_threshold_payout` — mints the 1.2M creator-token
+#      supply and routes it per ThresholdPayoutAmounts. Subsequent
+#      activity on the pool flips to AMM swap / liquidity mode.
+#
+# Sizing notes:
+#   - You must have at least the requested amount in BLUECHIP_DENOM
+#     in the deployer wallet. The slice-1 deploy minted
+#     BLUECHIP_INITIAL_MINT (10M BC); after seeding the anchor
+#     (8K BC) and funding expand-economy (10K BC) you have ~9.98M
+#     BC — so 60K BC fits trivially.
+#   - If the oracle hasn't published yet (you skipped slice 3's
+#     bootstrap confirm), the conversion will fail with "oracle has
+#     no published price" and the commit reverts. Confirm the
+#     bootstrap first via `test_bootstrap.sh confirm`.
+# =====================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/osmo_testnet.env"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_osmo_tx_helpers.sh"
+require_state
+
+POOL_ADDR="${1:-}"
+AMOUNT="${2:-60000000000}"  # 60_000 BC at 6 decimals
+if [ -z "$POOL_ADDR" ]; then
+    echo "usage: $0 <pool_addr> [bluechip-amount-micro]" >&2
+    echo ""
+    if [ -f "$SCRIPT_DIR/commit_pools.txt" ]; then
+        echo "known commit pools (from commit_pools.txt):" >&2
+        awk -F '\t' '{printf "  pool_id=%s addr=%s symbol=%s\n", $1, $2, $4}' \
+            "$SCRIPT_DIR/commit_pools.txt" >&2
+    else
+        echo "(commit_pools.txt not found — run create_commit_pool.sh first)" >&2
+    fi
+    exit 1
+fi
+
+echo "pool:        $POOL_ADDR"
+echo "committing:  $AMOUNT $BLUECHIP_DENOM"
+echo ""
+
+# Show the oracle-derived USD value of this commit before submitting,
+# so the operator can sanity-check sizing.
+if PRICE_RESP="$(query_smart "$FACTORY_ADDR" \
+    '{"internal_blue_chip_oracle_query":{"convert_bluechip_to_usd":{"amount":"'$AMOUNT'"}}}' 2>&1)"; then
+    USD_VALUE="$(echo "$PRICE_RESP" | jq -r '.amount // empty' 2>/dev/null || true)"
+    if [ -n "$USD_VALUE" ]; then
+        # USD is 6-decimal; print the human-readable value too
+        USD_HUMAN="$(awk -v u="$USD_VALUE" 'BEGIN { printf "%.2f", u/1000000 }')"
+        echo "oracle says: $AMOUNT $BLUECHIP_DENOM ≈ \$$USD_HUMAN USD"
+    fi
+else
+    echo "warning: convert_bluechip_to_usd query failed — oracle may"
+    echo "         not have a published price yet. The commit may revert."
+    echo "         Run \`bash test_bootstrap.sh confirm\` if needed."
+fi
+echo ""
+
+COMMIT_MSG="$(jq -nc \
+    --arg blue "$BLUECHIP_DENOM" \
+    --arg amt  "$AMOUNT" \
+    '{commit:{
+        asset:{
+            info:{bluechip:{denom:$blue}},
+            amount:$amt
+        },
+        transaction_deadline:null,
+        belief_price:null,
+        max_spread:null
+    }}')"
+
+RESULT="$(submit_tx wasm execute "$POOL_ADDR" "$COMMIT_MSG" \
+    --amount "${AMOUNT}${BLUECHIP_DENOM}")"
+echo "OK — tx $(echo "$RESULT" | jq -r '.txhash')"
+
+# Pull the threshold-state out of the response if present —
+# trigger_threshold_payout emits attributes when it fires.
+THRESHOLD_FIRED="$(extract_attr "$RESULT" wasm threshold_crossed)"
+USD_RAISED="$(extract_attr "$RESULT" wasm total_usd_raised)"
+if [ -n "$THRESHOLD_FIRED" ]; then
+    echo ""
+    echo "threshold_crossed=$THRESHOLD_FIRED"
+fi
+if [ -n "$USD_RAISED" ]; then
+    USD_HUMAN="$(awk -v u="$USD_RAISED" 'BEGIN { printf "%.2f", u/1000000 }')"
+    echo "total_usd_raised: \$$USD_HUMAN"
+fi
+
+# Show the pool's commit status from the dedicated query.
+echo ""
+echo "=== pool.is_fully_commited ==="
+if STATUS="$(query_smart "$POOL_ADDR" '{"is_fully_commited":{}}' 2>&1)"; then
+    echo "$STATUS"
+else
+    echo "(query failed: $STATUS)"
+fi
+
+echo ""
+echo "NEXT (if threshold crossed):"
+echo "  1. Force snapshot refresh so the now-eligible commit pool"
+echo "     enters the oracle sample set:"
+echo "     bash $SCRIPT_DIR/apply_oracle_eligibility.sh refresh"
+echo "  2. Watch rotation:"
+echo "     bash $SCRIPT_DIR/test_rotation.sh"

--- a/test_rotation.sh
+++ b/test_rotation.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# =====================================================================
+# test_rotation.sh — observe the oracle's pool-set rotation
+# =====================================================================
+# Usage:
+#   bash test_rotation.sh             show one-shot oracle state
+#   bash test_rotation.sh watch       poll every 60s, highlight changes
+#
+# What rotation looks like in the contract:
+#   - Every UPDATE_INTERVAL = 300s, a keeper calls UpdateOraclePrice.
+#   - Inside that handler, if more than ROTATION_INTERVAL = 3600s has
+#     elapsed since `last_rotation`, the sample set is re-randomized
+#     from the eligible-pool snapshot (anchor handled separately).
+#   - The snapshot is built from ORACLE_ELIGIBLE_POOLS ∪ (commit pools
+#     with COMMIT_POOLS_AUTO_ELIGIBLE=true). Slice 4 makes both inputs
+#     non-empty.
+#
+# This script is read-only — it doesn't drive UpdateOraclePrice or
+# RefreshOraclePoolSnapshot. Pair with:
+#   - test_twap_advance.sh update      to trigger a keeper update
+#   - apply_oracle_eligibility.sh refresh   to rebuild the snapshot
+# =====================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/osmo_testnet.env"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_osmo_tx_helpers.sh"
+require_state
+
+MODE="${1:-once}"
+
+show_state() {
+    echo "=== eligible_pool_snap (raw storage) ==="
+    SNAP="$(query_raw_storage "$FACTORY_ADDR" 'eligible_pool_snap')"
+    if [ -n "$SNAP" ]; then
+        echo "$SNAP" | jq '{
+            pool_count: (.pool_addresses | length),
+            captured_at_block,
+            pool_addresses,
+            bluechip_indices
+        }'
+    else
+        echo "(snapshot not built yet — happens lazily on the next oracle update,"
+        echo " or immediately when RefreshOraclePoolSnapshot is called.)"
+    fi
+    echo ""
+    echo "=== internal_oracle.selected_pools + rotation timing ==="
+    ORACLE="$(query_raw_storage "$FACTORY_ADDR" 'internal_oracle')"
+    if [ -n "$ORACLE" ]; then
+        echo "$ORACLE" | jq '{
+            selected_pool_count: (.selected_pools | length),
+            selected_pools,
+            last_rotation,
+            rotation_interval,
+            update_interval,
+            twap_price: .bluechip_price_cache.last_price,
+            last_update: .bluechip_price_cache.last_update,
+            observation_count: (.bluechip_price_cache.twap_observations | length)
+        }'
+        LAST_ROT="$(echo "$ORACLE" | jq -r '.last_rotation // 0')"
+        ROT_INT="$(echo "$ORACLE" | jq -r '.rotation_interval // 3600')"
+        if [ "$LAST_ROT" -gt 0 ]; then
+            NEXT_ROT=$(( LAST_ROT + ROT_INT ))
+            NOW_S="$(date -u +%s)"
+            REMAINING=$(( NEXT_ROT - NOW_S ))
+            echo ""
+            if [ "$REMAINING" -gt 0 ]; then
+                MIN=$(( REMAINING / 60 ))
+                echo "next rotation eligible in: ${REMAINING}s (~${MIN} min)"
+            else
+                echo "next rotation: ELAPSED — the next UpdateOraclePrice will rotate."
+            fi
+        fi
+    else
+        echo "(internal_oracle storage entry not found — oracle uninitialized)"
+    fi
+}
+
+case "$MODE" in
+    once|--once|query)
+        show_state
+        ;;
+    watch|--watch)
+        echo "polling every 60s. press Ctrl-C to stop."
+        echo ""
+        while true; do
+            echo "=== $(date -u +%H:%M:%SZ) ==="
+            show_state
+            echo ""
+            sleep 60
+        done
+        ;;
+    *)
+        echo "usage: $0 [once | watch]" >&2
+        exit 1
+        ;;
+esac

--- a/test_swing.sh
+++ b/test_swing.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# =====================================================================
+# test_swing.sh — trigger the 30% TWAP drift breaker on a target pool
+# =====================================================================
+# Slice 6. The objective: drive a single oversized swap on a thinly-
+# funded pool so reserves move >30% in one block, then verify the
+# next UpdateOraclePrice round either rejects the drift (steady-state
+# branch (a)) or buffers it as a candidate (post-reset branch (c) /
+# bootstrap branch (d)).
+#
+# Subcommands:
+#   query <pool_addr>          Show pool reserves + suggest a swap
+#                              size that crosses 30% drift.
+#   swap <pool_addr> <amount>  Execute a SimpleSwap on the pool with
+#                              <amount> BLUECHIP_DENOM as the offer
+#                              asset. Uses --amount and the canonical
+#                              bluechip side as the funded leg.
+#                              max_spread=0.99 + allow_high_max_spread=true
+#                              so the pool's spread cap doesn't reject
+#                              the trade itself — we want the swap
+#                              to LAND so the breaker has something to
+#                              react to.
+#   observe <pool_addr>        Read pool.pool_state and show the
+#                              accumulator + reserve pre/post snapshot,
+#                              plus current factory.GetBluechipUsdPrice.
+#
+# Operator workflow:
+#   1. PICK A POOL THAT IS NOT THE ANCHOR. The anchor needs to stay
+#      healthy through bootstrap + TWAP + staleness tests. Use one of
+#      the commit pools created in slice 4 (commit_pools.txt has them).
+#      Verify it's threshold-crossed (cross_threshold.sh already ran)
+#      and oracle-eligible (apply_oracle_eligibility.sh apply ran).
+#
+#   2. Optional: thin out the pool's bluechip side. The 30% threshold
+#      bites on the SAMPLED reserves at oracle-update time. With a
+#      tiny pool, an attacker-sized swap (or you, in this test) can
+#      shove it past 30% trivially. Specifically aim for the pool's
+#      bluechip-side reserve to be near — but above —
+#      MIN_POOL_LIQUIDITY_FALLBACK_BLUECHIP_PER_SIDE (5_000 BC). Below
+#      that and M-4's per-side floor drops the pool from the eligible
+#      set entirely, defeating the test.
+#
+#   3. bash test_swing.sh query <pool_addr>
+#      Reads reserves and suggests an amount that pushes drift past
+#      30%. For an xyk pool with reserves (R, R'), a swap of x in
+#      moves the spot price by roughly (1 + x/R) factor; >30% drift
+#      needs x ≈ 0.3 * R on the offer side.
+#
+#   4. bash test_swing.sh swap <pool_addr> <amount>
+#      Submits the SimpleSwap. Pool's spread cap will permit it
+#      because we pass allow_high_max_spread=true.
+#
+#   5. bash test_swing.sh observe <pool_addr>
+#      Captures post-swap state. Then wait UPDATE_INTERVAL (300s) and
+#      drive the next oracle update:
+#        bash test_twap_advance.sh update
+#      Then re-observe + check rotation state. The breaker either:
+#        - rejected the new TWAP (branch (a) on steady-state); the
+#          oracle's last_price stays put and the bad observation is
+#          dropped from the rolling window. Look for
+#          `breaker_branch_a_rejected_drift` style attributes in the
+#          tx events.
+#        - buffered the drift as a candidate (branches (b)/(c)/(d)
+#          during warm-up windows). pending_first_price gets set;
+#          confirm with test_bootstrap.sh query.
+# =====================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/osmo_testnet.env"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_osmo_tx_helpers.sh"
+require_state
+
+usage() {
+    cat >&2 <<EOF
+usage:
+  $0 query <pool_addr>
+  $0 swap <pool_addr> <amount-micro-bluechip>
+  $0 observe <pool_addr>
+
+example:
+  $0 query osmo1...pool_addr
+  $0 swap osmo1...pool_addr 2000000000
+  $0 observe osmo1...pool_addr
+EOF
+    exit 1
+}
+
+MODE="${1:-}"
+POOL_ADDR="${2:-}"
+[ -z "$MODE" ] && usage
+[ -z "$POOL_ADDR" ] && usage
+
+# Resolve the bluechip-side reserve (which side is bluechip depends on
+# pool creation order). pool.pair returns the asset list in canonical
+# order; pool.pool_state returns reserves in matching order.
+resolve_pool_state() {
+    local pair pool_state
+    pair="$(query_smart "$POOL_ADDR" '{"pair":{}}')"
+    pool_state="$(query_smart "$POOL_ADDR" '{"pool_state":{}}')"
+
+    # Find which index holds the canonical bluechip denom.
+    local bluechip_idx
+    bluechip_idx="$(echo "$pair" | jq -r --arg d "$BLUECHIP_DENOM" '
+        (.pool_token_info // .asset_infos // []) |
+        to_entries[] | select(.value.bluechip.denom == $d) | .key' 2>/dev/null | head -n 1)"
+    if [ -z "$bluechip_idx" ]; then
+        echo "error: could not find $BLUECHIP_DENOM in pool's pair info" >&2
+        echo "$pair" | jq .
+        return 1
+    fi
+
+    echo "=== pool.pair ==="
+    echo "$pair" | jq .
+    echo ""
+    echo "=== pool.pool_state ==="
+    echo "$pool_state" | jq .
+    echo ""
+    echo "bluechip side index: $bluechip_idx"
+
+    BLUECHIP_RESERVE="$(echo "$pool_state" | jq -r --argjson i "$bluechip_idx" '
+        if $i == 0 then .reserve0 else .reserve1 end' 2>/dev/null)"
+    echo "bluechip reserve:    $BLUECHIP_RESERVE"
+}
+
+case "$MODE" in
+    query)
+        resolve_pool_state
+        echo ""
+        # Suggest a swap size: ~35% of the bluechip-side reserve so
+        # post-swap drift comfortably clears the 30% breaker threshold.
+        # 35% gives 5pp of slack against the keeper sampling exactly
+        # the pre-swap or post-swap state.
+        if [ -n "${BLUECHIP_RESERVE:-}" ] && [ "$BLUECHIP_RESERVE" -gt 0 ]; then
+            SUGGEST=$(( BLUECHIP_RESERVE * 35 / 100 ))
+            echo "=== suggested swap (35% of bluechip reserve) ==="
+            echo "  bash $0 swap $POOL_ADDR $SUGGEST"
+            echo ""
+            echo "  This pushes spot price by ~35% which exceeds the"
+            echo "  MAX_TWAP_DRIFT_BPS = 3000 (30%) breaker threshold"
+            echo "  on the next UpdateOraclePrice round."
+        fi
+        ;;
+    swap)
+        AMOUNT="${3:-}"
+        [ -z "$AMOUNT" ] && usage
+        echo "executing simple_swap with allow_high_max_spread=true"
+        echo "offer: $AMOUNT $BLUECHIP_DENOM → $POOL_ADDR"
+        echo ""
+        SWAP_MSG="$(jq -nc \
+            --arg blue "$BLUECHIP_DENOM" \
+            --arg amt  "$AMOUNT" \
+            '{simple_swap:{
+                offer_asset:{
+                    info:{bluechip:{denom:$blue}},
+                    amount:$amt
+                },
+                belief_price:null,
+                max_spread:"0.99",
+                allow_high_max_spread:true,
+                to:null,
+                transaction_deadline:null
+            }}')"
+        RESULT="$(submit_tx wasm execute "$POOL_ADDR" "$SWAP_MSG" \
+            --amount "${AMOUNT}${BLUECHIP_DENOM}")"
+        echo "OK — tx $(echo "$RESULT" | jq -r '.txhash')"
+        RETURN_AMOUNT="$(extract_attr "$RESULT" wasm return_amount)"
+        SPREAD_AMOUNT="$(extract_attr "$RESULT" wasm spread_amount)"
+        echo "received: ${RETURN_AMOUNT:-?} (spread: ${SPREAD_AMOUNT:-?})"
+        echo ""
+        echo "NEXT:"
+        echo "  1. wait UPDATE_INTERVAL (300s) for the keeper-update cooldown"
+        echo "  2. fire it manually:  bash test_twap_advance.sh update"
+        echo "  3. observe breaker:   bash $0 observe $POOL_ADDR"
+        ;;
+    observe)
+        resolve_pool_state
+        echo ""
+        echo "=== factory.GetBluechipUsdPrice ==="
+        if PRICE_RESP="$(query_smart "$FACTORY_ADDR" \
+            '{"internal_blue_chip_oracle_query":{"get_bluechip_usd_price":{}}}' 2>&1)"; then
+            echo "$PRICE_RESP" | jq .
+        else
+            echo "(query failed: $PRICE_RESP)"
+        fi
+        echo ""
+        echo "=== internal_oracle.bluechip_price_cache (raw storage) ==="
+        ORACLE="$(query_raw_storage "$FACTORY_ADDR" 'internal_oracle')"
+        if [ -n "$ORACLE" ]; then
+            echo "$ORACLE" | jq '{
+                last_price: .bluechip_price_cache.last_price,
+                last_update: .bluechip_price_cache.last_update,
+                observation_count: (.bluechip_price_cache.twap_observations | length),
+                pending_first_price,
+                warmup_remaining,
+                consecutive_failures
+            }'
+        fi
+        echo ""
+        echo "=== pending_bootstrap_price (raw storage) ==="
+        PENDING="$(query_raw_storage "$FACTORY_ADDR" 'pending_bootstrap_price')"
+        if [ -n "$PENDING" ]; then
+            echo "$PENDING" | jq .
+        else
+            echo "(no pending bootstrap candidate — already published or never reached)"
+        fi
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
Slice 4 — apply timelock + commit-pool ramp-up:
- apply_oracle_eligibility.sh: query | apply | cancel | refresh. apply lands ApplySetCommitPoolsAutoEligible (after the 48h wait proposed in slice 2) and immediately follows with RefreshOraclePoolSnapshot so the new flag value takes effect without waiting on the lazy 5-day refresh inside select_random_pools_with_atom.
- create_commit_pool.sh <name> <symbol>: factory.Create with the post-cleanup CreatePool shape (only pool_token_info + token_info). Client-side enforces validate_creator_token_info bounds (3-50 ASCII name, 3-12 A-Z+0-9 symbol with at least one letter, decimal=6) so obvious mistakes don't burn a tx. Pays the per-pool fee in BLUECHIP_DENOM. Resolves the pool / creator-token / NFT addresses from instantiate events and appends one TSV line per pool to commit_pools.txt as the source of truth for downstream slices.
- cross_threshold.sh <pool_addr> [amount]: commits BLUECHIP into a commit pool and reads back the threshold-crossed event + total_usd_raised. Defaults to 60_000 BC (well above $25k threshold across the OSMO/USD spot range the test plan assumes). Pre-flight query of factory.ConvertBluechipToUsd shows the expected USD value so the operator can sanity-check sizing before the tx lands.

Slice 5 — rotation observability:
- test_rotation.sh once | watch: read-only, queries the ELIGIBLE_POOL_SNAPSHOT and INTERNAL_ORACLE raw storage entries. Reports selected_pool_count, last_rotation timestamp, time-until- next-rotation against ROTATION_INTERVAL = 3600s. Watch mode polls every 60s and prints fresh state so changes between rotations are visible without manual re-runs.

Slice 6 — 30% drift breaker:
- test_swing.sh query | swap | observe <pool_addr> [amount]. query reads pool.pair + pool.pool_state, finds the bluechip-side index, and suggests a 35%-of-reserve swap that comfortably crosses MAX_TWAP_DRIFT_BPS = 3000. swap submits SimpleSwap with max_spread=0.99 and allow_high_max_spread=true so the pool's per-trade slippage cap permits the deliberately-oversized trade (we want the swap to LAND so the breaker has something to react to on the next keeper update). observe captures the breaker state via the raw INTERNAL_ORACLE entry — last_price, pending_first_price, warmup_remaining, consecutive_failures, plus pending_bootstrap_price for the bootstrap-branch case.

End-to-end run order is documented in each script's header. The operator drives the cadence (UPDATE_INTERVAL waits, keeper updates via test_twap_advance.sh update) so wall-clock costs are visible.