### PR TITLE
tests: cover top-priority coverage gaps across creator-pool/factory/s…

### DIFF
--- a/creator-pool/src/testing/threshold_tests.rs
+++ b/creator-pool/src/testing/threshold_tests.rs
@@ -1191,6 +1191,108 @@ fn test_unpaused_pool_accepts_commit_after_previously_paused() {
 }
 
 // ===========================================================================
+// Audit b8b0bcb: per-pool min commit floors — CommitTooSmall coverage
+// ===========================================================================
+//
+// `commit::execute_commit_logic` rejects any commit whose oracle-priced USD
+// value lands below the active floor — pre-threshold floor when
+// `IS_THRESHOLD_HIT == false`, post-threshold floor otherwise. The two tests
+// below pin both branches with the default floors set in `setup_pool_storage`
+// (pre = $5 / post = $1, both in 6-decimal USD).
+//
+// `with_factory_oracle(rate = 1_000_000)` makes the mock oracle treat ubluechip
+// 1:1 with 6-decimal USD micros, so the commit amount in ubluechip is also the
+// resulting `usd_value` in micros — easy to pin to one micro below the floor.
+
+#[test]
+fn test_commit_rejects_below_pre_threshold_floor() {
+    let mut deps = mock_dependencies_with_balance(&[Coin {
+        denom: "ubluechip".to_string(),
+        amount: Uint128::new(100_000_000),
+    }]);
+    setup_pool_storage(&mut deps);
+    with_factory_oracle(&mut deps, Uint128::new(1_000_000));
+
+    // One micro under the default pre-threshold floor ($5.000000).
+    let pre_floor = crate::state::DEFAULT_MIN_COMMIT_USD_PRE_THRESHOLD;
+    let just_below = pre_floor.checked_sub(Uint128::one()).unwrap();
+
+    let info = message_info(
+        &Addr::unchecked("alice"),
+        &[Coin {
+            denom: "ubluechip".to_string(),
+            amount: just_below,
+        }],
+    );
+    let msg = ExecuteMsg::Commit {
+        asset: TokenInfo {
+            info: TokenType::Native {
+                denom: "ubluechip".to_string(),
+            },
+            amount: just_below,
+        },
+        transaction_deadline: None,
+        belief_price: None,
+        max_spread: None,
+    };
+
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    match err {
+        ContractError::CommitTooSmall { got, min, phase } => {
+            assert_eq!(got, just_below);
+            assert_eq!(min, pre_floor);
+            assert_eq!(phase, "pre-threshold");
+        }
+        other => panic!("expected CommitTooSmall(pre-threshold), got {:?}", other),
+    }
+}
+
+#[test]
+fn test_commit_rejects_below_post_threshold_floor() {
+    let mut deps = mock_dependencies_with_balance(&[Coin {
+        denom: "ubluechip".to_string(),
+        amount: Uint128::new(100_000_000),
+    }]);
+    setup_pool_storage(&mut deps);
+    // Flip into post-threshold mode. Floor check fires before swap-path
+    // setup so pre-existing reserves aren't required.
+    IS_THRESHOLD_HIT.save(&mut deps.storage, &true).unwrap();
+    with_factory_oracle(&mut deps, Uint128::new(1_000_000));
+
+    let post_floor = crate::state::DEFAULT_MIN_COMMIT_USD_POST_THRESHOLD;
+    let just_below = post_floor.checked_sub(Uint128::one()).unwrap();
+
+    let info = message_info(
+        &Addr::unchecked("alice"),
+        &[Coin {
+            denom: "ubluechip".to_string(),
+            amount: just_below,
+        }],
+    );
+    let msg = ExecuteMsg::Commit {
+        asset: TokenInfo {
+            info: TokenType::Native {
+                denom: "ubluechip".to_string(),
+            },
+            amount: just_below,
+        },
+        transaction_deadline: None,
+        belief_price: None,
+        max_spread: None,
+    };
+
+    let err = execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
+    match err {
+        ContractError::CommitTooSmall { got, min, phase } => {
+            assert_eq!(got, just_below);
+            assert_eq!(min, post_floor);
+            assert_eq!(phase, "post-threshold");
+        }
+        other => panic!("expected CommitTooSmall(post-threshold), got {:?}", other),
+    }
+}
+
+// ===========================================================================
 // Fix 6: NATIVE_RAISED_FROM_COMMIT stores net-of-fees, not gross
 // ===========================================================================
 //

--- a/creator-pool/src/testing/update_pool_tests.rs
+++ b/creator-pool/src/testing/update_pool_tests.rs
@@ -1,12 +1,13 @@
 use cosmwasm_std::{
     testing::{message_info, mock_dependencies, mock_env},
-    Addr, Decimal,
+    Addr, Decimal, Uint128,
 };
 
 use crate::{
     contract::execute,
     error::ContractError,
     msg::{ExecuteMsg, PoolConfigUpdate},
+    state::{COMMIT_LIMIT_INFO, MAX_MIN_COMMIT_USD},
     testing::liquidity_tests::setup_pool_storage,
 };
 
@@ -51,4 +52,154 @@ fn test_pool_update_config_from_factory() {
     .unwrap_err();
 
     assert!(matches!(err, ContractError::Unauthorized {}));
+}
+
+/// Audit b8b0bcb: per-pool commit floors are tunable but must be > 0 and
+/// <= `MAX_MIN_COMMIT_USD`. The apply-side guard rejects zero on
+/// `min_commit_usd_pre_threshold` (defense-in-depth — factory's
+/// `PoolConfigUpdate::validate()` rejects the same at propose time, but
+/// the pool must not trust a stale or migrated `PendingPoolConfig`).
+#[test]
+fn test_update_config_rejects_zero_pre_threshold_floor() {
+    let mut deps = mock_dependencies();
+    setup_pool_storage(&mut deps);
+
+    let factory_info = message_info(&Addr::unchecked("factory_contract"), &[]);
+    let update = PoolConfigUpdate {
+        min_commit_usd_pre_threshold: Some(Uint128::zero()),
+        ..Default::default()
+    };
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        factory_info,
+        ExecuteMsg::UpdateConfigFromFactory { update },
+    )
+    .unwrap_err();
+
+    match err {
+        ContractError::InvalidCommitFloor { field, got, max } => {
+            assert_eq!(field, "min_commit_usd_pre_threshold");
+            assert_eq!(got, Uint128::zero());
+            assert_eq!(max, MAX_MIN_COMMIT_USD);
+        }
+        other => panic!("expected InvalidCommitFloor, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_update_config_rejects_zero_post_threshold_floor() {
+    let mut deps = mock_dependencies();
+    setup_pool_storage(&mut deps);
+
+    let factory_info = message_info(&Addr::unchecked("factory_contract"), &[]);
+    let update = PoolConfigUpdate {
+        min_commit_usd_post_threshold: Some(Uint128::zero()),
+        ..Default::default()
+    };
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        factory_info,
+        ExecuteMsg::UpdateConfigFromFactory { update },
+    )
+    .unwrap_err();
+
+    match err {
+        ContractError::InvalidCommitFloor { field, got, max } => {
+            assert_eq!(field, "min_commit_usd_post_threshold");
+            assert_eq!(got, Uint128::zero());
+            assert_eq!(max, MAX_MIN_COMMIT_USD);
+        }
+        other => panic!("expected InvalidCommitFloor, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_update_config_rejects_pre_floor_above_max() {
+    let mut deps = mock_dependencies();
+    setup_pool_storage(&mut deps);
+
+    let factory_info = message_info(&Addr::unchecked("factory_contract"), &[]);
+    let too_high = MAX_MIN_COMMIT_USD + Uint128::one();
+    let update = PoolConfigUpdate {
+        min_commit_usd_pre_threshold: Some(too_high),
+        ..Default::default()
+    };
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        factory_info,
+        ExecuteMsg::UpdateConfigFromFactory { update },
+    )
+    .unwrap_err();
+
+    match err {
+        ContractError::InvalidCommitFloor { field, got, max } => {
+            assert_eq!(field, "min_commit_usd_pre_threshold");
+            assert_eq!(got, too_high);
+            assert_eq!(max, MAX_MIN_COMMIT_USD);
+        }
+        other => panic!("expected InvalidCommitFloor, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_update_config_rejects_post_floor_above_max() {
+    let mut deps = mock_dependencies();
+    setup_pool_storage(&mut deps);
+
+    let factory_info = message_info(&Addr::unchecked("factory_contract"), &[]);
+    let too_high = MAX_MIN_COMMIT_USD + Uint128::one();
+    let update = PoolConfigUpdate {
+        min_commit_usd_post_threshold: Some(too_high),
+        ..Default::default()
+    };
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        factory_info,
+        ExecuteMsg::UpdateConfigFromFactory { update },
+    )
+    .unwrap_err();
+
+    match err {
+        ContractError::InvalidCommitFloor { field, got, max } => {
+            assert_eq!(field, "min_commit_usd_post_threshold");
+            assert_eq!(got, too_high);
+            assert_eq!(max, MAX_MIN_COMMIT_USD);
+        }
+        other => panic!("expected InvalidCommitFloor, got {:?}", other),
+    }
+}
+
+/// Positive boundary: a value equal to `MAX_MIN_COMMIT_USD` must succeed
+/// and persist on both fields simultaneously.
+#[test]
+fn test_update_config_accepts_floors_at_max_boundary() {
+    let mut deps = mock_dependencies();
+    setup_pool_storage(&mut deps);
+
+    let factory_info = message_info(&Addr::unchecked("factory_contract"), &[]);
+    let update = PoolConfigUpdate {
+        min_commit_usd_pre_threshold: Some(MAX_MIN_COMMIT_USD),
+        min_commit_usd_post_threshold: Some(MAX_MIN_COMMIT_USD),
+        ..Default::default()
+    };
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        factory_info,
+        ExecuteMsg::UpdateConfigFromFactory { update },
+    )
+    .unwrap();
+
+    let stored = COMMIT_LIMIT_INFO.load(&deps.storage).unwrap();
+    assert_eq!(stored.min_commit_usd_pre_threshold, MAX_MIN_COMMIT_USD);
+    assert_eq!(stored.min_commit_usd_post_threshold, MAX_MIN_COMMIT_USD);
 }

--- a/factory/src/testing/coverage_gap_tests.rs
+++ b/factory/src/testing/coverage_gap_tests.rs
@@ -1,0 +1,620 @@
+//! Coverage-gap tests for factory paths that had no Rust regression cover
+//! prior to this file. Groups:
+//!
+//! - `must_pay` surplus refund on commit-pool `Create` (audit f944e07).
+//! - `SetPythConfThresholdBps` bounds + auth (range
+//!   `[PYTH_CONF_THRESHOLD_BPS_MIN, PYTH_CONF_THRESHOLD_BPS_MAX]` =
+//!   `[50, 500]`, admin-only).
+//! - Oracle-allowlist error variants that the timelock/cancel/remove
+//!   tests in `oracle_eligibility_tests` don't currently fire:
+//!   `OracleEligiblePoolAlreadyAdded`,
+//!   `OracleEligiblePoolMissingBluechipSide`,
+//!   `OracleEligiblePoolAddAlreadyPending`,
+//!   `NoPendingOracleEligiblePoolAdd`,
+//!   `OracleEligiblePoolNotAllowlisted`,
+//!   `CommitPoolsAutoEligibleAlreadyPending`,
+//!   `NoPendingCommitPoolsAutoEligible`.
+
+use cosmwasm_std::testing::{message_info, mock_env, MockApi, MockStorage};
+use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg, Decimal, OwnedDeps, Uint128};
+
+use crate::asset::TokenType;
+use crate::error::ContractError;
+use crate::execute::{execute, instantiate};
+use crate::mock_querier::{mock_dependencies, WasmMockQuerier};
+use crate::msg::{CreatorTokenInfo, ExecuteMsg};
+use crate::pool_struct::{CreatePool, PoolDetails};
+use crate::state::{
+    load_pyth_conf_threshold_bps, FactoryInstantiate, ADMIN_TIMELOCK_SECONDS,
+    COMMIT_POOLS_AUTO_ELIGIBLE, ORACLE_ELIGIBLE_POOLS, PENDING_COMMIT_POOLS_AUTO_ELIGIBLE,
+    POOLS_BY_CONTRACT_ADDRESS, POOLS_BY_ID, POOL_COUNTER, PYTH_CONF_THRESHOLD_BPS,
+    PYTH_CONF_THRESHOLD_BPS_MAX, PYTH_CONF_THRESHOLD_BPS_MIN,
+};
+use crate::testing::tests::setup_atom_pool;
+use pool_factory_interfaces::PoolStateResponseForFactory;
+
+// --- shared helpers --------------------------------------------------------
+
+fn make_addr(label: &str) -> Addr {
+    MockApi::default().addr_make(label)
+}
+
+fn admin() -> Addr {
+    make_addr("admin")
+}
+
+fn default_factory_config() -> FactoryInstantiate {
+    FactoryInstantiate {
+        cw721_nft_contract_id: 58,
+        factory_admin_address: admin(),
+        commit_threshold_limit_usd: Uint128::new(25_000_000_000),
+        pyth_contract_addr_for_conversions: make_addr("oracle0000").to_string(),
+        pyth_atom_usd_price_feed_id: "ORCL".to_string(),
+        cw20_token_contract_id: 10,
+        create_pool_wasm_contract_id: 11,
+        standard_pool_wasm_contract_id: 0,
+        bluechip_wallet_address: make_addr("ubluechip"),
+        commit_fee_bluechip: Decimal::percent(1),
+        commit_fee_creator: Decimal::percent(5),
+        max_bluechip_lock_per_pool: Uint128::new(10_000_000_000),
+        creator_excess_liquidity_lock_days: 14,
+        atom_bluechip_anchor_pool_address: make_addr("atom_bluechip_pool"),
+        bluechip_mint_contract_address: None,
+        bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
+        standard_pool_creation_fee_usd: Uint128::new(1_000_000),
+        threshold_payout_amounts: Default::default(),
+        emergency_withdraw_delay_seconds: 86_400,
+    }
+}
+
+fn fresh_factory() -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+    let mut deps = mock_dependencies(&[]);
+    setup_atom_pool(&mut deps);
+    instantiate(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        default_factory_config(),
+    )
+    .unwrap();
+    deps
+}
+
+// ---------------------------------------------------------------------------
+// must_pay surplus refund
+// ---------------------------------------------------------------------------
+
+/// Audit f944e07: commit-pool `Create` enforces `must_pay` on the bluechip
+/// denom and the configured USD fee converted via the live oracle.
+/// Bootstrap state (no oracle warm-up yet) falls back to
+/// `STANDARD_POOL_CREATION_FEE_FALLBACK_BLUECHIP = 100_000_000 ubluechip`.
+/// Overpaying that amount must produce a Bank `Send` refunding the surplus
+/// to `info.sender` inside the same response.
+#[test]
+fn create_pool_refunds_surplus_to_sender() {
+    let mut deps = fresh_factory();
+
+    let required: u128 = 100_000_000;
+    let surplus: u128 = 50_000_000;
+    let paid = Uint128::new(required + surplus);
+
+    let funds = vec![Coin {
+        denom: "ubluechip".to_string(),
+        amount: paid,
+    }];
+    let info = message_info(&admin(), &funds);
+
+    let create_msg = ExecuteMsg::Create {
+        pool_msg: CreatePool {
+            pool_token_info: [
+                TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                TokenType::CreatorToken {
+                    contract_addr: Addr::unchecked("WILL_BE_CREATED_BY_FACTORY"),
+                },
+            ],
+        },
+        token_info: CreatorTokenInfo {
+            name: "RefundToken".to_string(),
+            symbol: "REFUND".to_string(),
+            decimal: 6,
+        },
+    };
+
+    let res = execute(deps.as_mut(), mock_env(), info, create_msg).unwrap();
+
+    // Exactly one BankMsg::Send must address the sender with the surplus
+    // amount of ubluechip. (The other potential BankMsg from this
+    // response — the fee transfer — addresses the bluechip wallet, not
+    // the sender.)
+    let admin_addr_str = admin().to_string();
+    let refund_match = res.messages.iter().find_map(|sub| match &sub.msg {
+        CosmosMsg::Bank(BankMsg::Send { to_address, amount }) if to_address == &admin_addr_str => {
+            amount
+                .iter()
+                .find(|c| c.denom == "ubluechip" && c.amount == Uint128::new(surplus))
+                .map(|_| ())
+        }
+        _ => None,
+    });
+    assert!(
+        refund_match.is_some(),
+        "expected BankMsg::Send refunding {} ubluechip to {}, got {:?}",
+        surplus,
+        admin_addr_str,
+        res.messages
+    );
+}
+
+/// Negative complement: paying *exactly* `required_bluechip` must NOT
+/// emit any BankMsg targeting `info.sender` — the surplus branch is
+/// guarded on `!surplus.is_zero()`.
+#[test]
+fn create_pool_exact_pay_emits_no_refund() {
+    let mut deps = fresh_factory();
+
+    let funds = vec![Coin {
+        denom: "ubluechip".to_string(),
+        amount: Uint128::new(100_000_000),
+    }];
+    let info = message_info(&admin(), &funds);
+
+    let create_msg = ExecuteMsg::Create {
+        pool_msg: CreatePool {
+            pool_token_info: [
+                TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                TokenType::CreatorToken {
+                    contract_addr: Addr::unchecked("WILL_BE_CREATED_BY_FACTORY"),
+                },
+            ],
+        },
+        token_info: CreatorTokenInfo {
+            name: "ExactToken".to_string(),
+            symbol: "EXACT".to_string(),
+            decimal: 6,
+        },
+    };
+
+    let res = execute(deps.as_mut(), mock_env(), info, create_msg).unwrap();
+
+    let admin_addr_str = admin().to_string();
+    let any_refund = res.messages.iter().any(|sub| {
+        matches!(&sub.msg, CosmosMsg::Bank(BankMsg::Send { to_address, .. }) if to_address == &admin_addr_str)
+    });
+    assert!(
+        !any_refund,
+        "exact-pay create must not emit a refund BankMsg to sender; got {:?}",
+        res.messages
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SetPythConfThresholdBps bounds + auth
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_pyth_conf_threshold_bps_rejects_below_min() {
+    let mut deps = fresh_factory();
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::SetPythConfThresholdBps {
+            bps: PYTH_CONF_THRESHOLD_BPS_MIN - 1,
+        },
+    )
+    .unwrap_err();
+    match err {
+        ContractError::Std(e) => {
+            let s = e.to_string();
+            assert!(
+                s.contains("out of allowed range"),
+                "expected range error, got {}",
+                s
+            );
+        }
+        other => panic!("expected Std range error, got {:?}", other),
+    }
+}
+
+#[test]
+fn set_pyth_conf_threshold_bps_rejects_above_max() {
+    let mut deps = fresh_factory();
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::SetPythConfThresholdBps {
+            bps: PYTH_CONF_THRESHOLD_BPS_MAX + 1,
+        },
+    )
+    .unwrap_err();
+    match err {
+        ContractError::Std(e) => {
+            assert!(e.to_string().contains("out of allowed range"));
+        }
+        other => panic!("expected Std range error, got {:?}", other),
+    }
+}
+
+#[test]
+fn set_pyth_conf_threshold_bps_accepts_min_and_max_boundaries() {
+    let mut deps = fresh_factory();
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::SetPythConfThresholdBps {
+            bps: PYTH_CONF_THRESHOLD_BPS_MIN,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        load_pyth_conf_threshold_bps(&deps.storage),
+        PYTH_CONF_THRESHOLD_BPS_MIN
+    );
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::SetPythConfThresholdBps {
+            bps: PYTH_CONF_THRESHOLD_BPS_MAX,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        PYTH_CONF_THRESHOLD_BPS.load(&deps.storage).unwrap(),
+        PYTH_CONF_THRESHOLD_BPS_MAX
+    );
+}
+
+#[test]
+fn set_pyth_conf_threshold_bps_rejects_non_admin() {
+    let mut deps = fresh_factory();
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&make_addr("hacker"), &[]),
+        ExecuteMsg::SetPythConfThresholdBps { bps: 200 },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::Unauthorized {}));
+}
+
+// ---------------------------------------------------------------------------
+// Oracle-allowlist error variants
+// ---------------------------------------------------------------------------
+
+/// Pool registration helper for the allowlist tests. Mirrors the
+/// `register_standard_pool_with_reserves` helper in
+/// `oracle_eligibility_tests` but keeps this file self-contained.
+fn register_standard_pool_with_bluechip_side(
+    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier>,
+    pool_id: u64,
+    addr: &Addr,
+) {
+    let pool_details = PoolDetails {
+        pool_id,
+        pool_token_info: [
+            TokenType::Native {
+                denom: "ubluechip".to_string(),
+            },
+            TokenType::CreatorToken {
+                contract_addr: Addr::unchecked(format!("creator_token_{}", pool_id)),
+            },
+        ],
+        creator_pool_addr: addr.clone(),
+        pool_kind: pool_factory_interfaces::PoolKind::Standard,
+        commit_pool_ordinal: 0,
+    };
+    POOLS_BY_ID.save(deps.as_mut().storage, pool_id, &pool_details).unwrap();
+    crate::state::POOL_ID_BY_ADDRESS
+        .save(deps.as_mut().storage, addr.clone(), &pool_id)
+        .unwrap();
+    let counter = POOL_COUNTER.may_load(deps.as_ref().storage).unwrap().unwrap_or(0);
+    if pool_id > counter {
+        POOL_COUNTER.save(deps.as_mut().storage, &pool_id).unwrap();
+    }
+    POOLS_BY_CONTRACT_ADDRESS
+        .save(
+            deps.as_mut().storage,
+            addr.clone(),
+            &PoolStateResponseForFactory {
+                pool_contract_address: addr.clone(),
+                nft_ownership_accepted: true,
+                reserve0: Uint128::new(50_000_000_000),
+                reserve1: Uint128::new(50_000_000_000),
+                total_liquidity: Uint128::new(100_000_000_000),
+                block_time_last: 100,
+                price0_cumulative_last: Uint128::zero(),
+                price1_cumulative_last: Uint128::zero(),
+                assets: vec![],
+            },
+        )
+        .unwrap();
+}
+
+/// Standard pool whose token-info has NO bluechip side. Used to fire
+/// `OracleEligiblePoolMissingBluechipSide`.
+fn register_standard_pool_no_bluechip(
+    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier>,
+    pool_id: u64,
+    addr: &Addr,
+) {
+    let pool_details = PoolDetails {
+        pool_id,
+        pool_token_info: [
+            TokenType::Native {
+                denom: "uatom".to_string(),
+            },
+            TokenType::CreatorToken {
+                contract_addr: Addr::unchecked(format!("creator_token_{}", pool_id)),
+            },
+        ],
+        creator_pool_addr: addr.clone(),
+        pool_kind: pool_factory_interfaces::PoolKind::Standard,
+        commit_pool_ordinal: 0,
+    };
+    POOLS_BY_ID.save(deps.as_mut().storage, pool_id, &pool_details).unwrap();
+    crate::state::POOL_ID_BY_ADDRESS
+        .save(deps.as_mut().storage, addr.clone(), &pool_id)
+        .unwrap();
+    let counter = POOL_COUNTER.may_load(deps.as_ref().storage).unwrap().unwrap_or(0);
+    if pool_id > counter {
+        POOL_COUNTER.save(deps.as_mut().storage, &pool_id).unwrap();
+    }
+    POOLS_BY_CONTRACT_ADDRESS
+        .save(
+            deps.as_mut().storage,
+            addr.clone(),
+            &PoolStateResponseForFactory {
+                pool_contract_address: addr.clone(),
+                nft_ownership_accepted: true,
+                reserve0: Uint128::new(50_000_000_000),
+                reserve1: Uint128::new(50_000_000_000),
+                total_liquidity: Uint128::new(100_000_000_000),
+                block_time_last: 100,
+                price0_cumulative_last: Uint128::zero(),
+                price1_cumulative_last: Uint128::zero(),
+                assets: vec![],
+            },
+        )
+        .unwrap();
+}
+
+/// Run Propose + (after timelock) Apply for `pool_addr`. Leaves the pool
+/// allowlisted and the pending slot cleared.
+fn allowlist_pool(deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier>, pool_addr: &Addr) {
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeAddOracleEligiblePool {
+            pool_addr: pool_addr.to_string(),
+        },
+    )
+    .unwrap();
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(ADMIN_TIMELOCK_SECONDS + 1);
+    execute(
+        deps.as_mut(),
+        env,
+        message_info(&admin(), &[]),
+        ExecuteMsg::ApplyAddOracleEligiblePool {
+            pool_addr: pool_addr.to_string(),
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn propose_add_rejects_when_pool_already_allowlisted() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_usdc");
+    register_standard_pool_with_bluechip_side(&mut deps, 2, &std_pool);
+    allowlist_pool(&mut deps, &std_pool);
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::OracleEligiblePoolAlreadyAdded { .. }
+    ));
+}
+
+#[test]
+fn propose_add_rejects_when_pool_has_no_bluechip_side() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_atom_only");
+    register_standard_pool_no_bluechip(&mut deps, 2, &std_pool);
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::OracleEligiblePoolMissingBluechipSide { .. }
+    ));
+}
+
+#[test]
+fn propose_add_rejects_when_already_pending() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_usdc");
+    register_standard_pool_with_bluechip_side(&mut deps, 2, &std_pool);
+
+    // First propose lands pending.
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap();
+
+    // Second propose against the same pool must fail before clobbering
+    // the existing pending entry.
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::OracleEligiblePoolAddAlreadyPending { .. }
+    ));
+}
+
+#[test]
+fn apply_add_rejects_when_no_pending() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_usdc");
+    register_standard_pool_with_bluechip_side(&mut deps, 2, &std_pool);
+
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(ADMIN_TIMELOCK_SECONDS + 1);
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&admin(), &[]),
+        ExecuteMsg::ApplyAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::NoPendingOracleEligiblePoolAdd { .. }
+    ));
+}
+
+#[test]
+fn cancel_add_rejects_when_no_pending() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_usdc");
+    register_standard_pool_with_bluechip_side(&mut deps, 2, &std_pool);
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::CancelAddOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::NoPendingOracleEligiblePoolAdd { .. }
+    ));
+}
+
+#[test]
+fn remove_rejects_when_pool_not_allowlisted() {
+    let mut deps = fresh_factory();
+    let std_pool = make_addr("std_pool_usdc");
+    register_standard_pool_with_bluechip_side(&mut deps, 2, &std_pool);
+
+    // Never allowlisted — remove must reject.
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::RemoveOracleEligiblePool {
+            pool_addr: std_pool.to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::OracleEligiblePoolNotAllowlisted { .. }
+    ));
+    // Sanity: the storage row really is absent.
+    assert!(!ORACLE_ELIGIBLE_POOLS.has(&deps.storage, std_pool));
+}
+
+#[test]
+fn propose_auto_eligible_flip_rejects_when_already_pending() {
+    let mut deps = fresh_factory();
+    // setup_atom_pool flips COMMIT_POOLS_AUTO_ELIGIBLE to true, so to
+    // propose a *flip* the value the propose targets must differ from
+    // the live one.
+    let target = !COMMIT_POOLS_AUTO_ELIGIBLE.load(&deps.storage).unwrap();
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeSetCommitPoolsAutoEligible { enabled: target },
+    )
+    .unwrap();
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::ProposeSetCommitPoolsAutoEligible { enabled: target },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::CommitPoolsAutoEligibleAlreadyPending
+    ));
+    assert!(PENDING_COMMIT_POOLS_AUTO_ELIGIBLE
+        .may_load(&deps.storage)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn apply_auto_eligible_flip_rejects_when_no_pending() {
+    let mut deps = fresh_factory();
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(ADMIN_TIMELOCK_SECONDS + 1);
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&admin(), &[]),
+        ExecuteMsg::ApplySetCommitPoolsAutoEligible {},
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::NoPendingCommitPoolsAutoEligible));
+}
+
+#[test]
+fn cancel_auto_eligible_flip_rejects_when_no_pending() {
+    let mut deps = fresh_factory();
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&admin(), &[]),
+        ExecuteMsg::CancelSetCommitPoolsAutoEligible {},
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::NoPendingCommitPoolsAutoEligible));
+}

--- a/factory/src/testing/mod.rs
+++ b/factory/src/testing/mod.rs
@@ -1,4 +1,5 @@
 mod audit_tests;
+mod coverage_gap_tests;
 #[cfg(feature = "mock")]
 mod oracle_mock_test;
 mod oracle_repro;

--- a/standard-pool/src/testing/claim_emergency.rs
+++ b/standard-pool/src/testing/claim_emergency.rs
@@ -1,0 +1,431 @@
+//! `ClaimEmergencyShare` + `SweepUnclaimedEmergencyShares` coverage.
+//!
+//! Post-drain, LP funds escrow in `EMERGENCY_DRAIN_SNAPSHOT`. Each LP
+//! position can claim its pro-rata share at any time inside the
+//! `EMERGENCY_CLAIM_DORMANCY_SECONDS` (1 year) window. After dormancy,
+//! the factory may sweep the unclaimed residual to `bluechip_wallet`,
+//! which hard-closes the claim window.
+
+use cosmwasm_std::testing::{message_info, mock_env, MockApi};
+use cosmwasm_std::{
+    to_json_binary, Addr, BankMsg, Coin, ContractResult, CosmosMsg, SystemResult, Uint128,
+    WasmQuery,
+};
+use cw20::BalanceResponse as Cw20BalanceResponse;
+use pool_core::state::{
+    EMERGENCY_CLAIM_DORMANCY_SECONDS, EMERGENCY_DRAIN_SNAPSHOT, LIQUIDITY_POSITIONS,
+};
+use pool_factory_interfaces::cw721_msgs::{Cw721QueryMsg, OwnerOfResponse};
+
+use super::fixtures::{instantiate_default_pool, FixtureAddrs, BLUECHIP_DENOM};
+use crate::contract::execute;
+use crate::error::ContractError;
+use crate::msg::ExecuteMsg;
+
+type Deps = cosmwasm_std::OwnedDeps<
+    cosmwasm_std::testing::MockStorage,
+    cosmwasm_std::testing::MockApi,
+    cosmwasm_std::testing::MockQuerier,
+>;
+
+/// Re-wires `deps.querier` so:
+/// - the position-NFT contract reports `nft_owner` as the holder of every
+///   token (so `verify_position_ownership` accepts that sender),
+/// - factory queries (`EmergencyWithdrawDelaySeconds`, `BluechipWalletAddress`)
+///   return canonical values used by drain + sweep,
+/// - CW20 `Balance` queries return zero (deposit balance-verify path).
+fn rewire_querier(deps: &mut Deps, nft_owner: Addr, nft_contract: Addr, bluechip_wallet: Addr) {
+    let nft_contract = nft_contract.to_string();
+    deps.querier.update_wasm(move |query| match query {
+        WasmQuery::Smart { contract_addr, msg } => {
+            if *contract_addr == nft_contract {
+                if let Ok(Cw721QueryMsg::OwnerOf { .. }) = cosmwasm_std::from_json(msg) {
+                    let resp = OwnerOfResponse {
+                        owner: nft_owner.to_string(),
+                        approvals: vec![],
+                    };
+                    return SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()));
+                }
+            }
+            if let Ok(pool_factory_interfaces::FactoryQueryMsg::EmergencyWithdrawDelaySeconds {}) =
+                cosmwasm_std::from_json(msg)
+            {
+                let resp = pool_factory_interfaces::EmergencyWithdrawDelayResponse {
+                    delay_seconds: 86_400,
+                };
+                return SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()));
+            }
+            if let Ok(pool_factory_interfaces::FactoryQueryMsg::BluechipWalletAddress {}) =
+                cosmwasm_std::from_json(msg)
+            {
+                let resp = pool_factory_interfaces::BluechipWalletResponse {
+                    address: bluechip_wallet.clone(),
+                };
+                return SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()));
+            }
+            if let Ok(cw20::Cw20QueryMsg::Balance { .. }) = cosmwasm_std::from_json(msg) {
+                let resp = Cw20BalanceResponse {
+                    balance: Uint128::zero(),
+                };
+                return SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()));
+            }
+            SystemResult::Err(cosmwasm_std::SystemError::InvalidRequest {
+                error: format!("unexpected wasm query to {}", contract_addr),
+                request: msg.clone(),
+            })
+        }
+        _ => SystemResult::Err(cosmwasm_std::SystemError::UnsupportedRequest {
+            kind: "non-Smart wasm query".to_string(),
+        }),
+    });
+}
+
+/// Deposits one position from `addrs.pool_owner`, then runs Phase 1 +
+/// Phase 2 of emergency withdraw — leaving the pool in the drained
+/// state with `EMERGENCY_DRAIN_SNAPSHOT` populated. Returns the
+/// `position_id` minted on the deposit.
+fn setup_drained_pool() -> (Deps, FixtureAddrs, String) {
+    let (mut deps, addrs) = instantiate_default_pool();
+    rewire_querier(
+        &mut deps,
+        addrs.pool_owner.clone(),
+        addrs.position_nft.clone(),
+        addrs.bluechip_wallet.clone(),
+    );
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(
+            &addrs.pool_owner,
+            &[Coin::new(1_000_000_000u128, BLUECHIP_DENOM)],
+        ),
+        ExecuteMsg::DepositLiquidity {
+            amount0: Uint128::new(1_000_000_000),
+            amount1: Uint128::new(2_000_000_000),
+            min_amount0: None,
+            min_amount1: None,
+            transaction_deadline: None,
+        },
+    )
+    .unwrap();
+
+    // Phase 1.
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::EmergencyWithdraw {},
+    )
+    .unwrap();
+
+    // Phase 2 — 25h past instantiate.
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(25 * 3600);
+    execute(
+        deps.as_mut(),
+        env,
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::EmergencyWithdraw {},
+    )
+    .unwrap();
+
+    (deps, addrs, "1".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// ClaimEmergencyShare
+// ---------------------------------------------------------------------------
+
+#[test]
+fn claim_emergency_share_happy_path_sends_pro_rata_and_bumps_snapshot() {
+    let (mut deps, addrs, position_id) = setup_drained_pool();
+
+    // Snapshot pre-claim. The lone position holds 100% of total_liquidity,
+    // so it must receive the full drained amounts on both sides.
+    let pre = EMERGENCY_DRAIN_SNAPSHOT.load(&deps.storage).unwrap();
+    assert_eq!(pre.total_claimed_0, Uint128::zero());
+    assert_eq!(pre.total_claimed_1, Uint128::zero());
+    assert!(!pre.residual_swept);
+    let pre_position = LIQUIDITY_POSITIONS
+        .load(&deps.storage, &position_id)
+        .unwrap();
+    assert!(!pre_position.liquidity.is_zero());
+
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&addrs.pool_owner, &[]),
+        ExecuteMsg::ClaimEmergencyShare {
+            position_id: position_id.clone(),
+        },
+    )
+    .unwrap();
+
+    // Position economically spent.
+    let post_position = LIQUIDITY_POSITIONS
+        .load(&deps.storage, &position_id)
+        .unwrap();
+    assert_eq!(post_position.liquidity, Uint128::zero());
+    assert_eq!(post_position.unclaimed_fees_0, Uint128::zero());
+    assert_eq!(post_position.unclaimed_fees_1, Uint128::zero());
+
+    // Snapshot tally bumped to exactly the drained-side totals (sole LP
+    // owns 100% of total_liquidity_at_drain).
+    let post = EMERGENCY_DRAIN_SNAPSHOT.load(&deps.storage).unwrap();
+    assert_eq!(post.total_claimed_0, pre.reserve0_at_drain + pre.fee_reserve_0_at_drain);
+    assert_eq!(post.total_claimed_1, pre.reserve1_at_drain + pre.fee_reserve_1_at_drain);
+    assert!(!post.residual_swept, "single claim must not flip the sweep flag");
+
+    // Outgoing transfers: a Bank Send for the native side, a CW20
+    // Transfer for the creator-token side, both addressed to the
+    // claimant (pool_owner).
+    let bank_to_owner_native = res.messages.iter().any(|sub| match &sub.msg {
+        CosmosMsg::Bank(BankMsg::Send { to_address, amount }) => {
+            to_address == addrs.pool_owner.as_str()
+                && amount.iter().any(|c| c.denom == BLUECHIP_DENOM && !c.amount.is_zero())
+        }
+        _ => false,
+    });
+    assert!(bank_to_owner_native, "expected native pro-rata bank send to claimant");
+
+    let cw20_to_owner = res.messages.iter().any(|sub| match &sub.msg {
+        CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Execute { contract_addr, msg, .. }) => {
+            contract_addr == &addrs.creator_token.to_string()
+                && String::from_utf8_lossy(msg.as_slice()).contains(addrs.pool_owner.as_str())
+        }
+        _ => false,
+    });
+    assert!(cw20_to_owner, "expected CW20 pro-rata transfer to claimant");
+}
+
+#[test]
+fn claim_emergency_share_rejects_before_drain() {
+    let (mut deps, addrs) = instantiate_default_pool();
+    rewire_querier(
+        &mut deps,
+        addrs.pool_owner.clone(),
+        addrs.position_nft.clone(),
+        addrs.bluechip_wallet.clone(),
+    );
+
+    // Deposit, no emergency-drain.
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(
+            &addrs.pool_owner,
+            &[Coin::new(1_000_000_000u128, BLUECHIP_DENOM)],
+        ),
+        ExecuteMsg::DepositLiquidity {
+            amount0: Uint128::new(1_000_000_000),
+            amount1: Uint128::new(2_000_000_000),
+            min_amount0: None,
+            min_amount1: None,
+            transaction_deadline: None,
+        },
+    )
+    .unwrap();
+
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&addrs.pool_owner, &[]),
+        ExecuteMsg::ClaimEmergencyShare {
+            position_id: "1".to_string(),
+        },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::NoEmergencyDrainSnapshot));
+}
+
+#[test]
+fn claim_emergency_share_rejects_wrong_nft_owner() {
+    let (mut deps, _addrs, position_id) = setup_drained_pool();
+    let attacker = MockApi::default().addr_make("attacker");
+
+    // The querier still says `pool_owner` owns the NFT, so a claim sent
+    // by `attacker` must fail the ownership gate.
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&attacker, &[]),
+        ExecuteMsg::ClaimEmergencyShare { position_id },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::Unauthorized {}));
+}
+
+#[test]
+fn claim_emergency_share_rejects_after_claim_zeroes_liquidity() {
+    let (mut deps, addrs, position_id) = setup_drained_pool();
+
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&addrs.pool_owner, &[]),
+        ExecuteMsg::ClaimEmergencyShare {
+            position_id: position_id.clone(),
+        },
+    )
+    .unwrap();
+
+    // Position liquidity is now zero — second claim must reject.
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        message_info(&addrs.pool_owner, &[]),
+        ExecuteMsg::ClaimEmergencyShare { position_id },
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::NoClaimableEmergencyShare { .. }
+    ));
+}
+
+#[test]
+fn claim_emergency_share_rejects_post_sweep() {
+    let (mut deps, addrs, position_id) = setup_drained_pool();
+
+    // Advance past dormancy and sweep first.
+    let mut env = mock_env();
+    env.block.time = env
+        .block
+        .time
+        .plus_seconds(25 * 3600 + EMERGENCY_CLAIM_DORMANCY_SECONDS + 1);
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap();
+
+    // Now a (late) claim must hard-fail with the post-sweep gate, NOT
+    // silently succeed and bump total_claimed_* beyond drainable.
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&addrs.pool_owner, &[]),
+        ExecuteMsg::ClaimEmergencyShare { position_id },
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::EmergencyClaimsClosedPostSweep));
+}
+
+// ---------------------------------------------------------------------------
+// SweepUnclaimedEmergencyShares
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sweep_rejects_non_factory() {
+    let (mut deps, _addrs, _) = setup_drained_pool();
+    let attacker = MockApi::default().addr_make("attacker");
+
+    let mut env = mock_env();
+    env.block.time = env
+        .block
+        .time
+        .plus_seconds(25 * 3600 + EMERGENCY_CLAIM_DORMANCY_SECONDS + 1);
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&attacker, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::Unauthorized {}));
+}
+
+#[test]
+fn sweep_rejects_before_dormancy_elapsed() {
+    let (mut deps, addrs, _) = setup_drained_pool();
+
+    // 23h past drain — well inside the 1-year dormancy.
+    let mut env = mock_env();
+    env.block.time = env.block.time.plus_seconds(25 * 3600 + 23 * 3600);
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        ContractError::EmergencyClaimDormancyNotElapsed { .. }
+    ));
+}
+
+#[test]
+fn sweep_post_dormancy_sends_residual_to_wallet_and_flips_flag() {
+    let (mut deps, addrs, _) = setup_drained_pool();
+
+    // No prior claims, so the entire drained amount is residual.
+    let pre = EMERGENCY_DRAIN_SNAPSHOT.load(&deps.storage).unwrap();
+    assert_eq!(pre.total_claimed_0, Uint128::zero());
+    assert_eq!(pre.total_claimed_1, Uint128::zero());
+    assert!(!pre.residual_swept);
+
+    let mut env = mock_env();
+    env.block.time = env
+        .block
+        .time
+        .plus_seconds(25 * 3600 + EMERGENCY_CLAIM_DORMANCY_SECONDS + 1);
+    let res = execute(
+        deps.as_mut(),
+        env,
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap();
+
+    let post = EMERGENCY_DRAIN_SNAPSHOT.load(&deps.storage).unwrap();
+    assert!(post.residual_swept, "sweep must flip the residual_swept flag");
+
+    // Every outgoing transfer must address the bluechip wallet (the
+    // factory's live-queried wallet — rewired by the fixture).
+    let bank_to_wallet = res.messages.iter().any(|sub| match &sub.msg {
+        CosmosMsg::Bank(BankMsg::Send { to_address, .. }) => {
+            to_address == addrs.bluechip_wallet.as_str()
+        }
+        _ => false,
+    });
+    let cw20_to_wallet = res.messages.iter().any(|sub| match &sub.msg {
+        CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Execute { contract_addr, msg, .. }) => {
+            contract_addr == &addrs.creator_token.to_string()
+                && String::from_utf8_lossy(msg.as_slice()).contains(addrs.bluechip_wallet.as_str())
+        }
+        _ => false,
+    });
+    assert!(bank_to_wallet, "sweep must Bank-send the native residual to bluechip wallet");
+    assert!(cw20_to_wallet, "sweep must CW20-transfer the creator-token residual to bluechip wallet");
+}
+
+#[test]
+fn sweep_rejects_double_call() {
+    let (mut deps, addrs, _) = setup_drained_pool();
+
+    let mut env = mock_env();
+    env.block.time = env
+        .block
+        .time
+        .plus_seconds(25 * 3600 + EMERGENCY_CLAIM_DORMANCY_SECONDS + 1);
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap();
+
+    let err = execute(
+        deps.as_mut(),
+        env,
+        message_info(&addrs.factory, &[]),
+        ExecuteMsg::SweepUnclaimedEmergencyShares {},
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContractError::NoUnclaimedEmergencyResidual));
+}

--- a/standard-pool/src/testing/mod.rs
+++ b/standard-pool/src/testing/mod.rs
@@ -6,6 +6,7 @@
 
 mod accept_nft_ownership;
 mod balance_verify;
+mod claim_emergency;
 mod collect_fees;
 mod deposit_liquidity;
 mod emergency_withdraw;


### PR DESCRIPTION
…tandard-pool

Five priority groups from the coverage audit. All new tests pass and the existing 600+-test workspace suite is unchanged.

creator-pool (7 tests, threshold_tests + update_pool_tests):
- CommitTooSmall pre- and post-threshold floor enforcement (audit b8b0bcb).
- InvalidCommitFloor on UpdateConfigFromFactory — zero and >MAX_MIN_COMMIT_USD on both min_commit_usd_pre_threshold and min_commit_usd_post_threshold, plus a positive boundary case at MAX_MIN_COMMIT_USD.

standard-pool (9 tests, new claim_emergency.rs):
- ClaimEmergencyShare happy path: pro-rata bank Send + CW20 Transfer to claimant, snapshot total_claimed_* bumped, position liquidity zeroed.
- ClaimEmergencyShare rejection paths: NoEmergencyDrainSnapshot before drain, Unauthorized on wrong NFT owner, NoClaimableEmergencyShare after the first claim zeroes liquidity, EmergencyClaimsClosedPostSweep after a dormancy sweep.
- SweepUnclaimedEmergencyShares: Unauthorized for non-factory, EmergencyClaimDormancyNotElapsed before the 1-year window, happy-path sweep routes residual to the factory-queried bluechip wallet and flips residual_swept, NoUnclaimedEmergencyResidual on double-call.

factory (15 tests, new coverage_gap_tests.rs):
- must_pay surplus refund on Create (audit f944e07): overpaying emits a BankMsg::Send returning the surplus to info.sender; exact pay emits no refund.
- SetPythConfThresholdBps bounds + auth: rejects below MIN (50 bps), rejects above MAX (500 bps), accepts both boundaries, rejects non-admin caller.
- Oracle-allowlist error variants (audit 09ba0b9): seven error paths none of the existing eligibility tests fire — OracleEligiblePoolAlreadyAdded, OracleEligiblePoolMissingBluechipSide, OracleEligiblePoolAddAlreadyPending, NoPendingOracleEligiblePoolAdd (on both Apply and Cancel), OracleEligiblePoolNotAllowlisted on Remove, CommitPoolsAutoEligibleAlreadyPending, and NoPendingCommitPoolsAutoEligible on both Apply and Cancel.