### PR TITLE
gas: dedupe address stringification + move-not-clone in deposit path

### DIFF
--- a/factory/src/pool_create_cleanup.rs
+++ b/factory/src/pool_create_cleanup.rs
@@ -91,11 +91,12 @@ pub fn give_pool_ownership_cw20_and_nft(
     nft_addr: &Addr,
     pool_addr: &Addr,
 ) -> Result<Vec<CosmosMsg>, ContractError> {
+    let pool_addr_str = pool_addr.to_string();
     Ok(vec![
         WasmMsg::Execute {
             contract_addr: token_addr.to_string(),
             msg: to_json_binary(&Cw20ExecuteMsg::UpdateMinter {
-                new_minter: Some(pool_addr.to_string()),
+                new_minter: Some(pool_addr_str.clone()),
             })?,
             funds: vec![],
         }
@@ -104,7 +105,7 @@ pub fn give_pool_ownership_cw20_and_nft(
             contract_addr: nft_addr.to_string(),
             msg: to_json_binary(&Cw721ExecuteMsg::<()>::UpdateOwnership(
                 Action::TransferOwnership {
-                    new_owner: pool_addr.to_string(),
+                    new_owner: pool_addr_str,
                     expiry: None,
                 },
             ))?,

--- a/factory/src/pool_creation_reply.rs
+++ b/factory/src/pool_creation_reply.rs
@@ -58,17 +58,18 @@ pub fn set_tokens(
     POOL_CREATION_CONTEXT.save(deps.storage, pool_id, &ctx)?;
 
     let config = FACTORYINSTANTIATEINFO.load(deps.storage)?;
+    let factory_addr_str = env.contract.address.to_string();
     let nft_instantiate_msg = to_json_binary(&Cw721InstantiateMsg {
         name: LP_NFT_NAME.to_string(),
         symbol: LP_NFT_SYMBOL.to_string(),
-        minter: env.contract.address.to_string(),
+        minter: factory_addr_str.clone(),
     })?;
 
     let nft_msg = WasmMsg::Instantiate {
         code_id: config.cw721_nft_contract_id,
         msg: nft_instantiate_msg,
         funds: vec![],
-        admin: Some(env.contract.address.to_string()),
+        admin: Some(factory_addr_str),
         label: format!("{}{}", LP_NFT_LABEL_PREFIX, token_address),
     };
 

--- a/packages/pool-core/src/liquidity/add.rs
+++ b/packages/pool-core/src/liquidity/add.rs
@@ -72,7 +72,7 @@ fn add_to_position_internal(
 ) -> Result<Response, ContractError> {
     enforce_transaction_deadline(env.block.time, transaction_deadline)?;
 
-    let prep = prepare_deposit(
+    let mut prep = prepare_deposit(
         deps.as_ref(),
         &info,
         amount0,
@@ -125,7 +125,13 @@ fn add_to_position_internal(
     let ((fees_owed_0, fees_owed_1), _, (clipped_0, clipped_1)) =
         calc_capped_fees_with_clip(&liquidity_position, &pool_fee_state)?;
 
-    let mut messages: Vec<CosmosMsg> = prep.collect_msgs.clone();
+    // Move (not clone) prep.collect_msgs. The remaining `prep` fields used
+    // below are all `Copy` (Uint128) or borrowed (`&prep.pool_info`), so
+    // the partial move is sound. Sized at 4 to absorb the up-to-2 collect
+    // msgs plus the up-to-2 fee-transfer msgs appended later (CW20 or
+    // BankMsg per non-zero fee side).
+    let mut messages: Vec<CosmosMsg> = Vec::with_capacity(4);
+    messages.append(&mut prep.collect_msgs);
 
     liquidity_position.liquidity = liquidity_position.liquidity.checked_add(prep.liquidity)?;
     liquidity_position.fee_growth_inside_0_last = pool_fee_state.fee_growth_global_0;

--- a/packages/pool-core/src/liquidity/deposit.rs
+++ b/packages/pool-core/src/liquidity/deposit.rs
@@ -186,7 +186,7 @@ pub(crate) fn prepare_deposit(
     check_slippage(actual_amount0, min_amount0, "asset0")?;
     check_slippage(actual_amount1, min_amount1, "asset1")?;
 
-    let mut collect_msgs: Vec<CosmosMsg> = Vec::new();
+    let mut collect_msgs: Vec<CosmosMsg> = Vec::with_capacity(2);
     let refund_amount0 = collect_deposit_side(
         &pool_info.pool_info.asset_infos[0],
         actual_amount0,
@@ -335,7 +335,7 @@ fn execute_deposit_liquidity_inner(
     min_amount1: Option<Uint128>,
     verify_balances: bool,
 ) -> Result<Response, ContractError> {
-    let prep = prepare_deposit(
+    let mut prep = prepare_deposit(
         deps.as_ref(),
         &info,
         amount0,
@@ -391,7 +391,11 @@ fn execute_deposit_liquidity_inner(
         Uint128::zero()
     };
 
-    let mut messages = vec![];
+    // Max 4 outgoing messages on this path: optional NFT-accept (1) +
+    // at-most-two collect msgs from prepare_deposit (2) + position-mint
+    // NFT (1). Sizing once here avoids the 1-2 reallocations a default
+    // Vec::new() would take as we push past its initial capacity.
+    let mut messages: Vec<CosmosMsg> = Vec::with_capacity(4);
     if !pool_state.nft_ownership_accepted {
         let accept_msg = WasmMsg::Execute {
             contract_addr: prep.pool_info.position_nft_address.to_string(),
@@ -406,8 +410,9 @@ fn execute_deposit_liquidity_inner(
 
     // prepare_deposit already dispatched per-asset and built the collection
     // messages (TransferFrom for CW20 sides, BankMsg refunds for over-paid
-    // native sides). Splice them into the response list.
-    messages.extend(prep.collect_msgs.clone());
+    // native sides). Moved (not cloned) into the response list — `prep`'s
+    // remaining fields are all `Copy` so the partial move is fine.
+    messages.append(&mut prep.collect_msgs);
 
     let mut pos_id = NEXT_POSITION_ID.load(deps.storage)?;
     pos_id = pos_id


### PR DESCRIPTION
Three small wins from the gas audit follow-up:

1. Bind `env.contract.address.to_string()` once in `set_tokens`, and `pool_addr.to_string()` once in `give_pool_ownership_cw20_and_nft`, instead of allocating a fresh String per use. Saves one String allocation in each function.

2. Move `prep.collect_msgs` into the response messages Vec instead of cloning it. Both `execute_deposit_liquidity_inner` and `add_to_position_internal` previously did `messages.extend(prep.collect_msgs.clone())`; `prep`'s remaining used fields are all `Copy` or borrowed, so the partial move is sound.

3. Pre-size the message vectors via `Vec::with_capacity` on the hot deposit/add paths (max 4 msgs in inner, 2 in `prepare_deposit`'s collect_msgs builder) — avoids 1-2 reallocations as the Vec grows.

No behavior change. All workspace tests pass.