### PR TITLE
security: HIGH-1 — defer commit_pool_ordinal allocation to threshold-…

### DIFF
--- a/factory/src/execute/pool_lifecycle/admin.rs
+++ b/factory/src/execute/pool_lifecycle/admin.rs
@@ -15,7 +15,7 @@ use cosmwasm_std::{
 
 use crate::error::ContractError;
 use crate::mint_bluechips_pool_creation::calculate_and_mint_bluechip;
-use crate::state::{POOLS_BY_ID, POOL_THRESHOLD_MINTED};
+use crate::state::{COMMIT_POOL_COUNTER, POOLS_BY_ID, POOL_THRESHOLD_MINTED};
 
 use super::super::ensure_admin;
 
@@ -218,6 +218,32 @@ pub fn execute_notify_threshold_crossed(
     }
 
     POOL_THRESHOLD_MINTED.save(deps.storage, pool_id, &true)?;
+
+    // Allocate the commit-pool ordinal here, at threshold-cross time —
+    // NOT at create time. Junk-create pools that never cross threshold
+    // therefore do not consume an ordinal slot, so they cannot inflate
+    // the bluechip-mint decay formula's `x` input for legitimate future
+    // crossings. The counter is bumped after the POOL_THRESHOLD_MINTED
+    // idempotency check above, so a `RetryFactoryNotify` after a failed
+    // initial dispatch does not double-allocate. CosmWasm storage
+    // atomicity guarantees: if `calculate_and_mint_bluechip` below
+    // fails (e.g. expand_economy daily-cap exceeded), the entire tx
+    // reverts including the bumps above — POOL_THRESHOLD_MINTED reverts
+    // to false, COMMIT_POOL_COUNTER reverts, and a later RetryFactoryNotify
+    // re-runs allocation cleanly.
+    let prior_counter = COMMIT_POOL_COUNTER.may_load(deps.storage)?.unwrap_or(0);
+    let new_ordinal = prior_counter
+        .checked_add(1)
+        .ok_or_else(|| ContractError::Std(StdError::generic_err(
+            "COMMIT_POOL_COUNTER overflow on threshold-cross allocation",
+        )))?;
+    COMMIT_POOL_COUNTER.save(deps.storage, &new_ordinal)?;
+    // Write the freshly-allocated ordinal back to PoolDetails so
+    // `calculate_and_mint_bluechip` (which re-loads PoolDetails) reads
+    // the assigned value rather than the create-time sentinel 0.
+    let mut pool_details = pool_details;
+    pool_details.commit_pool_ordinal = new_ordinal;
+    POOLS_BY_ID.save(deps.storage, pool_id, &pool_details)?;
 
     // Use the pool-supplied crossed_at when present (MEDIUM-2: anchors
     // the decay formula to the original crossing time so a retried

--- a/factory/src/execute/pool_lifecycle/create.rs
+++ b/factory/src/execute/pool_lifecycle/create.rs
@@ -17,7 +17,7 @@ use crate::error::ContractError;
 use crate::msg::{CreatorTokenInfo, TokenInstantiateMsg};
 use crate::pool_struct::{CreatePool, TempPoolCreation};
 use crate::state::{
-    canonical_pair_key, CreationStatus, COMMIT_POOL_COUNTER,
+    canonical_pair_key, CreationStatus,
     COMMIT_POOL_CREATE_RATE_LIMIT_SECONDS, FACTORYINSTANTIATEINFO, LAST_COMMIT_POOL_CREATE_AT,
     LAST_STANDARD_POOL_CREATE_AT, PAIRS, POOL_COUNTER, POOL_CREATION_CONTEXT,
     PoolCreationContext, PoolCreationState, STANDARD_POOL_CREATE_RATE_LIMIT_SECONDS,
@@ -324,13 +324,18 @@ pub(crate) fn execute_create_creator_pool(
     let pool_counter = POOL_COUNTER.may_load(deps.storage)?.unwrap_or(0);
     let pool_id = pool_counter + 1;
     POOL_COUNTER.save(deps.storage, &pool_id)?;
-    // Allocate the commit-pool-only ordinal. Bumped only here, never in
-    // `execute_create_standard_pool`, so the bluechip mint-decay formula
-    // sees a count of legitimate commit-pool creations rather than a
-    // count that permissionless standard-pool creation can inflate.
-    let commit_pool_counter = COMMIT_POOL_COUNTER.may_load(deps.storage)?.unwrap_or(0);
-    let commit_pool_ordinal = commit_pool_counter + 1;
-    COMMIT_POOL_COUNTER.save(deps.storage, &commit_pool_ordinal)?;
+    // Sentinel ordinal at create time. The real allocation happens at
+    // threshold-cross inside `execute_notify_threshold_crossed`, so the
+    // bluechip mint-decay formula's `x` reflects pools that actually
+    // reached threshold rather than pools that were merely created.
+    // Junk pools that never cross do not consume an ordinal slot and
+    // therefore cannot inflate the decay input for legitimate future
+    // crossings. The downstream guard in
+    // `calculate_and_mint_bluechip` (`if commit_pool_ordinal == 0:
+    // Err`) keeps the invariant load-bearing: any path that reaches
+    // the mint without going through the notify-handler's allocation
+    // fails closed.
+    let commit_pool_ordinal: u64 = 0;
 
     let msg = WasmMsg::Instantiate {
         code_id: factory_cw20.cw20_token_contract_id,

--- a/factory/src/mint_bluechips_pool_creation.rs
+++ b/factory/src/mint_bluechips_pool_creation.rs
@@ -159,22 +159,28 @@ pub fn calculate_and_mint_bluechip(
     // POOL_COUNTER) cannot inflate `x` and shrink legitimate commit pools'
     // mint reward toward zero.
     //
-    // Fail-loud invariant: `commit_pool_ordinal` is set on every commit
-    // pool at create time (`execute_create_creator_pool` in
-    // `factory/src/execute/pool_lifecycle/create.rs`) and is non-zero by
-    // construction (counter is bumped to `current + 1` before save).
-    // v1 is the launch version — there is no pre-existing chain state —
-    // so a zero ordinal at this point can only mean storage corruption.
+    // Fail-loud invariant: by the time `calculate_and_mint_bluechip` runs,
+    // `commit_pool_ordinal` MUST have been allocated by the immediately-
+    // preceding step in `execute_notify_threshold_crossed`, which bumps
+    // `COMMIT_POOL_COUNTER` and writes the new value back to
+    // `PoolDetails.commit_pool_ordinal` right after the
+    // `POOL_THRESHOLD_MINTED` idempotency check. Reaching this function
+    // with ordinal == 0 indicates a path that bypassed that allocation
+    // (storage corruption, or a future call site that calls this helper
+    // directly without going through the notify handler).
+    //
     // We reject rather than fall back: `calculate_mint_amount(s, 0)`
     // returns the FULL base amount (500_000_000), so a silent fallback
     // would *inflate* the mint relative to the intended schedule — the
-    // worst possible direction.
+    // worst possible direction. Commit pools at create time carry
+    // ordinal == 0 by design (sentinel); this branch is only reachable
+    // inside the mint flow, where allocation has already happened.
     if pool_details.commit_pool_ordinal == 0 {
         return Err(ContractError::Std(StdError::generic_err(format!(
-            "Pool {} has commit_pool_ordinal == 0; refusing to mint to avoid \
-             base-amount inflation in the decay formula. This indicates either \
-             a pre-v1 legacy record or storage corruption — investigate the \
-             pool's PoolDetails entry before retrying.",
+            "Pool {} has commit_pool_ordinal == 0 at mint time; refusing to mint \
+             to avoid base-amount inflation in the decay formula. The notify \
+             handler should have allocated it immediately above this call — \
+             investigate the call chain or PoolDetails entry before retrying.",
             pool_id
         ))));
     }

--- a/factory/src/pool_struct.rs
+++ b/factory/src/pool_struct.rs
@@ -215,27 +215,36 @@ pub struct PoolDetails {
     /// to standard-pool support was a commit pool.
     #[serde(default)]
     pub pool_kind: PoolKind,
-    /// 1-indexed ordinal among commit pools at the time this pool was
-    /// created. Always zero for standard pools. Consumed by the bluechip
-    /// mint-decay formula in `calculate_and_mint_bluechip` so that
-    /// permissionless standard-pool creation (which also bumps the
-    /// global `POOL_COUNTER`) cannot inflate `x` in the decay polynomial
-    /// and shrink legitimate commit pools' threshold-mint reward toward
-    /// zero.
+    /// 1-indexed ordinal among commit pools that have CROSSED THEIR
+    /// THRESHOLD (NOT the order in which pools were created). Always
+    /// zero for standard pools, and zero for commit pools that have
+    /// not yet crossed. Consumed by the bluechip mint-decay formula
+    /// in `calculate_and_mint_bluechip` as the polynomial input `x`.
     ///
-    /// Set non-zero at create time by `execute_create_creator_pool`
-    /// (the counter is bumped to `current + 1` before save), so a
-    /// commit pool with `commit_pool_ordinal == 0` indicates either
-    /// storage corruption or a pre-v1 legacy record. v1 is the launch
-    /// version — there is no legacy chain state to back-fill — so
+    /// Lifecycle:
+    /// 1. At create time (`execute_create_creator_pool`), this field
+    ///    is written as `0` (sentinel meaning "not yet allocated").
+    /// 2. At threshold-cross time (`execute_notify_threshold_crossed`,
+    ///    after the `POOL_THRESHOLD_MINTED` idempotency gate), the
+    ///    notify handler bumps `COMMIT_POOL_COUNTER` and writes the
+    ///    new value back here.
+    ///
+    /// Two layers of inflation defense are coupled here:
+    /// - Decouple from `POOL_COUNTER` so permissionless
+    ///   `CreateStandardPool` cannot inflate `x`.
+    /// - Decouple from create-time so paid junk-create spam (pools that
+    ///   never threshold-cross) cannot inflate `x` for legitimate future
+    ///   crossings. The counter advances only on real protocol activity.
+    ///
     /// `calculate_and_mint_bluechip` fail-closes (`Err`) on a zero
-    /// ordinal rather than falling back to a value that would
-    /// inflate the mint relative to the intended schedule.
+    /// ordinal — that branch is reachable only if some path bypasses
+    /// `execute_notify_threshold_crossed`'s allocation, which would be
+    /// a bug. Failing closed prevents the formula from inflating the
+    /// mint by treating zero as the (vacuously) lowest-ordinal slot.
     ///
-    /// `#[serde(default)]` is retained so a future migration that
-    /// extends `PoolDetails` with another field continues to
-    /// deserialize cleanly; it is NOT a back-compat shim for legacy
-    /// records (none exist).
+    /// `#[serde(default)]` is retained for future-field-extension
+    /// compatibility; v1 fresh chain state has no legacy records to
+    /// back-fill.
     #[serde(default)]
     pub commit_pool_ordinal: u64,
 }

--- a/factory/src/state.rs
+++ b/factory/src/state.rs
@@ -39,16 +39,25 @@ pub const POOL_CREATION_CONTEXT: Map<u64, PoolCreationContext> =
 pub const PENDING_CONFIG: Item<PendingConfig> = Item::new("pending_config");
 pub const POOL_COUNTER: Item<u64> = Item::new("pool_counter");
 
-/// Commit-pool-only ordinal. Bumped exactly once per `execute_create_creator_pool`
-/// and stored on the commit pool's `PoolDetails.commit_pool_ordinal` so the
-/// threshold-mint decay formula can use it as `x` instead of `pool_id`.
+/// Commit-pool threshold-cross ordinal allocator. Bumped exactly once per
+/// successful `execute_notify_threshold_crossed` call (after the
+/// `POOL_THRESHOLD_MINTED` idempotency gate), and the new value is
+/// written back to `PoolDetails.commit_pool_ordinal` for that pool. The
+/// bluechip mint-decay formula then uses this value as `x`.
 ///
-/// This split exists because `POOL_COUNTER` is bumped by both commit and
-/// standard pool creations; using `pool_id` directly in the decay formula
-/// would let permissionless `CreateStandardPool` calls inflate `x` and
-/// shrink (toward zero) the bluechip mint reward for legitimate commit
-/// pools created later. The dedicated counter keeps the decay schedule
-/// anchored to actual commit-pool creation activity.
+/// Two layers of inflation defense are at play here:
+/// 1. Decouple from `POOL_COUNTER` (which is bumped by every standard-pool
+///    creation too) so permissionless `CreateStandardPool` calls can't
+///    inflate `x`.
+/// 2. Decouple from create-time (which would let paid junk-create spam
+///    inflate `x` without the attacker ever crossing a threshold) so
+///    the counter advances only on real protocol activity.
+///
+/// Atomicity: incremented after `POOL_THRESHOLD_MINTED.save(true)` but
+/// before `calculate_and_mint_bluechip` dispatches the mint. Any failure
+/// downstream reverts the whole tx — including this bump — so a retried
+/// notify after a failed first attempt re-allocates from the same prior
+/// value (no slot is consumed by a failed cross-tx).
 pub const COMMIT_POOL_COUNTER: Item<u64> = Item::new("commit_pool_counter");
 
 // Three coupled pool-registry maps. They MUST stay in sync — every pool
@@ -528,12 +537,14 @@ pub struct PoolCreationState {
 pub struct PoolCreationContext {
     pub temp: TempPoolCreation,
     pub state: PoolCreationState,
-    /// Captured at commit-pool create time and threaded through the reply
-    /// chain into `PoolDetails.commit_pool_ordinal`. Stored on the context
-    /// rather than re-computed in `finalize_pool` so the ordinal is fixed
-    /// at create time even if a concurrent commit-pool create races —
-    /// commit pools share the global `COMMIT_POOL_COUNTER` allocator but
-    /// each pool's ordinal is locked in here on its own create tx.
+    /// Vestigial create-time sentinel. The real ordinal is now allocated
+    /// at threshold-cross time inside `execute_notify_threshold_crossed`,
+    /// so this field is always `0` for fresh contexts and is kept only
+    /// for storage-schema continuity (cw_serde requires every field in
+    /// the struct to round-trip). The reply chain still propagates this
+    /// value into `PoolDetails.commit_pool_ordinal` at `finalize_pool`,
+    /// where it lands as `0` — the notify handler overwrites it with
+    /// the real allocation at threshold-cross.
     #[serde(default)]
     pub commit_pool_ordinal: u64,
 }

--- a/factory/src/testing/tests.rs
+++ b/factory/src/testing/tests.rs
@@ -112,17 +112,19 @@ pub fn register_test_pool_addr(
                 ],
                 creator_pool_addr: pool_addr.clone(),
                 pool_kind: pool_factory_interfaces::PoolKind::Commit,
-                // Mirror what the real commit-pool create flow produces:
-                // `COMMIT_POOL_COUNTER` is bumped to `current + 1` and
-                // pinned onto `PoolDetails.commit_pool_ordinal` at create
-                // time, so the first commit pool gets ordinal 1, the second
-                // gets 2, etc. Tests in this file only register commit
-                // pools sequentially by `pool_id`, so `pool_id` is the
-                // correct ordinal here. The production code in
-                // `calculate_and_mint_bluechip` now hard-rejects ordinal
-                // 0 to prevent silent base-amount inflation in the decay
+                // Mirror what a post-threshold-cross pool looks like in the
+                // registry: `COMMIT_POOL_COUNTER` is now bumped at
+                // threshold-cross time (in `execute_notify_threshold_crossed`,
+                // not at create), and the new value is pinned onto
+                // `PoolDetails.commit_pool_ordinal`. This helper bypasses the
+                // notify handler and stamps PoolDetails directly, so it
+                // emits the ordinal that a fully-crossed pool would carry.
+                // Tests in this file only register pools sequentially by
+                // `pool_id`, so `pool_id` is the correct ordinal here.
+                // `calculate_and_mint_bluechip` hard-rejects ordinal 0 to
+                // prevent silent base-amount inflation in the decay
                 // formula, so this helper MUST emit a non-zero ordinal to
-                // remain a faithful test fixture.
+                // remain a faithful "post-cross pool" fixture.
                 commit_pool_ordinal: pool_id,
             },
         )


### PR DESCRIPTION
…cross

`COMMIT_POOL_COUNTER` was bumped inside `execute_create_creator_pool` and the resulting ordinal pinned onto `PoolDetails.commit_pool_ordinal` at create time. The bluechip mint-decay formula in
`calculate_and_mint_bluechip` then read this ordinal as its `x` input.

Effect: paid commit-pool creation spam (junk pools that never cross threshold) permanently inflates `x` for every future legitimate threshold-crossing pool, decaying the protocol's bluechip mint schedule toward zero without the attacker ever crossing a threshold themselves. At a $1 launch creation fee, ~$33k in fees + gas (plus rotation across ~33k addresses to bypass the 1h per-address rate limit) suppresses the mint to zero permanently.

Fix: allocate the ordinal at threshold-cross time inside `execute_notify_threshold_crossed`, immediately after the `POOL_THRESHOLD_MINTED` idempotency gate. Junk pools that never cross no longer consume an ordinal slot, so the decay input tracks real protocol activity (threshold crossings) instead of paid creation volume.

Atomicity is preserved across failure paths: `POOL_THRESHOLD_MINTED` flips, `COMMIT_POOL_COUNTER` bumps, and `POOLS_BY_ID` updates ride in the same tx as the mint dispatch. A failed mint reverts all three; `RetryFactoryNotify` then re-allocates from the same prior counter value, so no slot is ever consumed by a failed cross. The existing zero-guard at the consumer in `calculate_and_mint_bluechip` becomes load-bearing — any future path that bypasses the new allocation site fails closed instead of inflating the mint to the base 500e6 amount.

Migration: not required for fresh launch. If any deployment already has commit pools with non-zero `commit_pool_ordinal` from the pre-fix code, the notify handler will overwrite the field with the freshly allocated value at threshold-cross — since `POOL_THRESHOLD_MINTED` gates uncrossed pools, the overwrite is correct.

https://claude.ai/code/session_019mxdB2vwswjgipCUq2x4Fu