### PR TITLE
docs+tests: HIGH-1 follow-through — README, stale comments, regressio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Each creator pool receives:
 - Factory-configured fee structure (default: 1% protocol + 5% creator)
 - Bluechip tokens minted via the Expand Economy contract on threshold-crossing (up to 500 per pool, decreasing over time)
 
-A per-address rate limit (1 hour) on `Create` calls keeps an attacker from cheaply inflating the commit-pool ordinal that drives the expand-economy decay schedule.
+A per-address rate limit (1 hour) on `Create` calls plus a USD-denominated creation fee keep registry bloat and gas-amplified per-pool storage scans in check. The expand-economy decay schedule's `x` input is allocated at threshold-cross time (not create time), so junk-create spam cannot inflate it without the attacker also committing the full USD threshold per junk pool — making decay-grief economically self-defeating.
 
 ### Creating a Standard Pool
 
@@ -558,7 +558,7 @@ The standard-pool reply handler will reject the transaction if the CW20 has a tr
 - 2-block post-threshold cooldown delays the first swap so an attacker can't bundle a manipulative swap into the threshold-crossing block. After cooldown, a 100-block per-tx swap-cap ramp (0.5% → 100% of offer-side reserve, linear) bounds each individual trade on the freshly-seeded pool, preventing major sniping without freezing legitimate first traders.
 
 ### Per-Address Rate Limit on Pool Creation
-- 1-hour cooldown per `info.sender` on creator-pool creation. Defends against trivial spam-creates that would inflate the commit-pool ordinal and gas-amplify per-pool storage scans. Coordinated multi-address spam still has to fund and sign from each new address it rotates through.
+- 1-hour cooldown per `info.sender` on creator-pool creation, plus a USD-denominated creation fee. Defends against registry bloat and gas-amplified per-pool storage scans. The expand-economy decay input `x` is allocated at threshold-cross time (not create), so junk-create spam alone cannot inflate it; coordinated multi-address spam still has to fund and sign from each new address AND drive each junk pool across the full USD threshold to advance `x`.
 
 ### Standard-Pool / Pool-Core Defenses
 - **SubMsg-based deposit balance verification** (standard-pool only): each CW20-side TransferFrom is anchored by a `reply_on_success` SubMsg whose handler re-queries the post-balance and asserts equality with the credited delta. Strict equality (not `≥`) so both fee-on-transfer shortfalls and inflate-on-transfer overages revert.
@@ -652,7 +652,7 @@ mint_amount = 500 - ((5x² + x) / ((s / 6) + 333x))
 ```
 
 Where:
-- **x** = `commit_pool_ordinal` — a commit-pool-only counter (NOT the global `pool_id`). Standard-pool creations cannot inflate `x`.
+- **x** = `commit_pool_ordinal` — a 1-indexed counter of commit pools that have CROSSED THEIR THRESHOLD (NOT created). Allocated inside `execute_notify_threshold_crossed` immediately after the `POOL_THRESHOLD_MINTED` idempotency gate, so junk-created commit pools that never cross threshold do not inflate `x`. Standard-pool creations cannot inflate `x` either (separate counter, never bumped on the standard path).
 - **s** = seconds elapsed since the first threshold-crossing
 - **Result** is in whole tokens (multiplied by 10⁶ for micro-denomination)
 

--- a/factory/src/pool_creation_reply.rs
+++ b/factory/src/pool_creation_reply.rs
@@ -229,10 +229,13 @@ pub fn finalize_pool(
         // chain (triggered by ExecuteMsg::Create). Standard pools have
         // their own reply chain that sets pool_kind = Standard.
         pool_kind: pool_factory_interfaces::PoolKind::Commit,
-        // Captured at create time on `PoolCreationContext.commit_pool_ordinal`
-        // so the threshold-mint decay formula uses commit-pool-count
-        // semantics rather than a global pool counter mixed with
-        // permissionlessly-created standard pools.
+        // Sentinel 0 propagated from `PoolCreationContext.commit_pool_ordinal`.
+        // The real ordinal is allocated at threshold-cross time inside
+        // `execute_notify_threshold_crossed`, which overwrites this field.
+        // We still propagate `ctx.commit_pool_ordinal` rather than hardcoding
+        // 0 so the wire format stays uniform with any future migration that
+        // re-introduces create-time allocation; under current code it is
+        // always 0 for fresh pools.
         commit_pool_ordinal: ctx.commit_pool_ordinal,
     };
 

--- a/factory/src/testing/tests.rs
+++ b/factory/src/testing/tests.rs
@@ -2350,6 +2350,296 @@ fn test_bluechip_minting_on_threshold_crossing() {
     assert_eq!(pool_count, 1);
 }
 
+/// Regression test for the HIGH-1 audit fix:
+/// `commit_pool_ordinal` (and the `COMMIT_POOL_COUNTER` it's allocated from)
+/// must advance ONLY on threshold-cross, never on pool creation. This
+/// prevents paid junk-create spam from inflating the mint-decay formula's
+/// `x` input for legitimate future crossings.
+///
+/// The test:
+/// 1. Calls `ExecuteMsg::Create` and asserts `COMMIT_POOL_COUNTER` stays at
+///    its prior value (sentinel 0, no allocation at create-time).
+/// 2. Manually registers the pool with `commit_pool_ordinal: 0` (matching
+///    the create-time sentinel that the real reply chain would have written).
+/// 3. Calls `NotifyThresholdCrossed` and asserts:
+///    - `COMMIT_POOL_COUNTER` advances by exactly 1.
+///    - `PoolDetails.commit_pool_ordinal` is overwritten from 0 → 1.
+#[test]
+fn test_commit_pool_ordinal_advances_on_threshold_cross_not_create() {
+    let mut deps = mock_dependencies(&[]);
+
+    setup_atom_pool(&mut deps);
+    let msg = FactoryInstantiate {
+        factory_admin_address: admin_addr(),
+        cw721_nft_contract_id: 58,
+        commit_threshold_limit_usd: Uint128::new(25_000_000_000),
+        pyth_contract_addr_for_conversions: MockApi::default().addr_make("oracle0000").to_string(),
+        pyth_atom_usd_price_feed_id: "BLUECHIP".to_string(),
+        cw20_token_contract_id: 10,
+        create_pool_wasm_contract_id: 11,
+        standard_pool_wasm_contract_id: 0,
+        bluechip_wallet_address: bluechip_wallet_addr(),
+        commit_fee_bluechip: Decimal::percent(1),
+        commit_fee_creator: Decimal::percent(5),
+        max_bluechip_lock_per_pool: Uint128::new(10_000_000_000),
+        creator_excess_liquidity_lock_days: 7,
+        atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
+        bluechip_mint_contract_address: None,
+        bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
+        standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
+        threshold_payout_amounts: Default::default(),
+        emergency_withdraw_delay_seconds: 86_400,
+    };
+
+    let env = mock_env();
+    let info = message_info(&admin_addr(), &[]);
+    instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+    prime_oracle_for_first_update(&mut deps);
+
+    // Pre-state: counter at the sentinel zero (no commit pool has crossed yet).
+    let counter_before_create = crate::state::COMMIT_POOL_COUNTER
+        .may_load(&deps.storage)
+        .unwrap()
+        .unwrap_or(0);
+    assert_eq!(counter_before_create, 0);
+
+    // Phase 1: Create the commit pool. After the M-1 fix this must NOT bump
+    // COMMIT_POOL_COUNTER — the counter is now allocated at threshold-cross
+    // time inside `execute_notify_threshold_crossed`.
+    let create_msg = ExecuteMsg::Create {
+        pool_msg: create_test_pool_msg(),
+        token_info: CreatorTokenInfo {
+            name: "First Token".to_string(),
+            symbol: "FIRST".to_string(),
+            decimal: 6,
+        },
+    };
+    let create_info = message_info(&admin_addr(), &creation_fee_funds());
+    execute(deps.as_mut(), env.clone(), create_info, create_msg).unwrap();
+
+    let counter_after_create = crate::state::COMMIT_POOL_COUNTER
+        .may_load(&deps.storage)
+        .unwrap()
+        .unwrap_or(0);
+    assert_eq!(
+        counter_after_create, 0,
+        "COMMIT_POOL_COUNTER must NOT advance on create — this is the M-1 \
+         regression invariant. Allocation moved to execute_notify_threshold_crossed."
+    );
+
+    // Phase 2: Register the pool with `commit_pool_ordinal: 0` — matching
+    // the create-time sentinel that the real reply chain writes via
+    // `PoolCreationContext.commit_pool_ordinal: 0`.
+    let pool_addr = Addr::unchecked("pool_contract_1");
+    crate::state::POOLS_BY_ID
+        .save(
+            deps.as_mut().storage,
+            1,
+            &PoolDetails {
+                pool_id: 1,
+                pool_token_info: [
+                    TokenType::Native {
+                        denom: "ubluechip".to_string(),
+                    },
+                    TokenType::CreatorToken {
+                        contract_addr: Addr::unchecked("token"),
+                    },
+                ],
+                creator_pool_addr: pool_addr.clone(),
+                pool_kind: pool_factory_interfaces::PoolKind::Commit,
+                // Create-time sentinel: zero until threshold-cross allocates.
+                commit_pool_ordinal: 0,
+            },
+        )
+        .unwrap();
+    crate::state::POOL_ID_BY_ADDRESS
+        .save(deps.as_mut().storage, pool_addr.clone(), &1u64)
+        .unwrap();
+
+    // Phase 3: Notify threshold crossed. This is the call that allocates the
+    // ordinal under the M-1 fix.
+    let notify_msg = ExecuteMsg::NotifyThresholdCrossed {
+        pool_id: 1,
+        crossed_at: None,
+    };
+    let pool_info = message_info(&pool_addr, &[]);
+    execute(deps.as_mut(), env.clone(), pool_info, notify_msg).unwrap();
+
+    // Post-state assertions:
+    //  (a) COMMIT_POOL_COUNTER advances exactly once.
+    //  (b) The pool's PoolDetails.commit_pool_ordinal is overwritten from 0 → 1.
+    let counter_after_cross = crate::state::COMMIT_POOL_COUNTER
+        .load(&deps.storage)
+        .unwrap();
+    assert_eq!(
+        counter_after_cross, 1,
+        "COMMIT_POOL_COUNTER must advance to 1 on the first threshold-cross."
+    );
+
+    let pool_details_after_cross = crate::state::POOLS_BY_ID
+        .load(&deps.storage, 1)
+        .unwrap();
+    assert_eq!(
+        pool_details_after_cross.commit_pool_ordinal, 1,
+        "Pool 1's commit_pool_ordinal must be overwritten from the sentinel 0 \
+         to the freshly-allocated value 1 at threshold-cross."
+    );
+}
+
+/// Regression test for the HIGH-1 audit fix:
+/// Junk pools that are created but never threshold-cross MUST NOT consume
+/// ordinal slots. A legitimate pool created AFTER N junk creates and then
+/// crossed must receive ordinal 1 (not N+1), so the mint formula treats it
+/// as the first real crossing.
+///
+/// This is the economic invariant the fix protects: paid create-spam can't
+/// decay the bluechip mint stream for honest creators.
+#[test]
+fn test_junk_creates_do_not_inflate_ordinal_for_legitimate_crosser() {
+    let mut deps = mock_dependencies(&[]);
+
+    setup_atom_pool(&mut deps);
+    let msg = FactoryInstantiate {
+        factory_admin_address: admin_addr(),
+        cw721_nft_contract_id: 58,
+        commit_threshold_limit_usd: Uint128::new(25_000_000_000),
+        pyth_contract_addr_for_conversions: MockApi::default().addr_make("oracle0000").to_string(),
+        pyth_atom_usd_price_feed_id: "BLUECHIP".to_string(),
+        cw20_token_contract_id: 10,
+        create_pool_wasm_contract_id: 11,
+        standard_pool_wasm_contract_id: 0,
+        bluechip_wallet_address: bluechip_wallet_addr(),
+        commit_fee_bluechip: Decimal::percent(1),
+        commit_fee_creator: Decimal::percent(5),
+        max_bluechip_lock_per_pool: Uint128::new(10_000_000_000),
+        creator_excess_liquidity_lock_days: 7,
+        atom_bluechip_anchor_pool_address: atom_bluechip_pool_addr(),
+        bluechip_mint_contract_address: None,
+        bluechip_denom: "ubluechip".to_string(),
+        atom_denom: "uatom".to_string(),
+        standard_pool_creation_fee_usd: cosmwasm_std::Uint128::new(1_000_000),
+        threshold_payout_amounts: Default::default(),
+        emergency_withdraw_delay_seconds: 86_400,
+    };
+
+    let mut env = mock_env();
+    let info = message_info(&admin_addr(), &[]);
+    instantiate(deps.as_mut(), env.clone(), info, msg).unwrap();
+    prime_oracle_for_first_update(&mut deps);
+
+    // Simulate 3 junk creates from 3 distinct attacker addresses. Each
+    // ExecuteMsg::Create bumps POOL_COUNTER but, under the M-1 fix, must
+    // NOT bump COMMIT_POOL_COUNTER. We advance block time past the per-
+    // address rate-limit between creates (each address has a 1h cooldown).
+    for i in 0..3 {
+        let attacker = MockApi::default().addr_make(&format!("attacker_{i}"));
+        let create_msg = ExecuteMsg::Create {
+            pool_msg: create_test_pool_msg(),
+            token_info: CreatorTokenInfo {
+                name: format!("Junk-{i}"),
+                symbol: format!("JUNK{i}"),
+                decimal: 6,
+            },
+        };
+        let attacker_info = message_info(&attacker, &creation_fee_funds());
+        env.block.time = env.block.time.plus_seconds(3700);
+        execute(deps.as_mut(), env.clone(), attacker_info, create_msg).unwrap();
+    }
+
+    let counter_after_3_junk = crate::state::COMMIT_POOL_COUNTER
+        .may_load(&deps.storage)
+        .unwrap()
+        .unwrap_or(0);
+    assert_eq!(
+        counter_after_3_junk, 0,
+        "Three junk creates (without threshold-cross) must NOT advance \
+         COMMIT_POOL_COUNTER. M-1 regression: prior to the fix this would \
+         have been 3, decaying the next legitimate pool's mint."
+    );
+
+    // Now register the LEGITIMATE pool 4 with create-time sentinel ordinal 0
+    // and cross its threshold. It must receive ordinal 1 (the FIRST real
+    // cross), so the decay formula treats it as `x=1` and emits the full
+    // base mint (not a value decayed by `x=4`).
+    let pool_addr = Addr::unchecked("pool_contract_4");
+    crate::state::POOLS_BY_ID
+        .save(
+            deps.as_mut().storage,
+            4,
+            &PoolDetails {
+                pool_id: 4,
+                pool_token_info: [
+                    TokenType::Native {
+                        denom: "ubluechip".to_string(),
+                    },
+                    TokenType::CreatorToken {
+                        contract_addr: Addr::unchecked("token"),
+                    },
+                ],
+                creator_pool_addr: pool_addr.clone(),
+                pool_kind: pool_factory_interfaces::PoolKind::Commit,
+                commit_pool_ordinal: 0,
+            },
+        )
+        .unwrap();
+    crate::state::POOL_ID_BY_ADDRESS
+        .save(deps.as_mut().storage, pool_addr.clone(), &4u64)
+        .unwrap();
+
+    let notify_msg = ExecuteMsg::NotifyThresholdCrossed {
+        pool_id: 4,
+        crossed_at: None,
+    };
+    let pool_info = message_info(&pool_addr, &[]);
+    let res = execute(deps.as_mut(), env.clone(), pool_info, notify_msg).unwrap();
+
+    let counter_after_cross = crate::state::COMMIT_POOL_COUNTER
+        .load(&deps.storage)
+        .unwrap();
+    assert_eq!(
+        counter_after_cross, 1,
+        "Pool 4 is the FIRST to cross threshold, so COMMIT_POOL_COUNTER \
+         must be 1 — NOT 4 (which would be the create-order count)."
+    );
+
+    let pool_details_after_cross = crate::state::POOLS_BY_ID
+        .load(&deps.storage, 4)
+        .unwrap();
+    assert_eq!(
+        pool_details_after_cross.commit_pool_ordinal, 1,
+        "Pool 4's ordinal must be 1 — the first crossing. If this assertion \
+         ever fails, the M-1 regression has returned: junk creates are \
+         decaying the mint stream for honest creators."
+    );
+
+    // Bonus: assert the mint amount in the response is close to the
+    // undecayed base (≈ 500 bluechip), confirming the formula sees x=1.
+    let mint_bank_msg = res
+        .messages
+        .iter()
+        .find_map(|m| match &m.msg {
+            CosmosMsg::Bank(BankMsg::Send { to_address, amount })
+                if to_address == bluechip_wallet_addr().as_str() =>
+            {
+                Some(amount[0].amount)
+            }
+            _ => None,
+        })
+        .expect("Threshold-cross must produce a mint bank-send to the protocol wallet");
+    // At x=1, s=0: 500e6 - (5+1)*1e6/333 ≈ 499.98e6
+    assert!(
+        mint_bank_msg > Uint128::new(499_000_000),
+        "Mint amount with x=1 should be near base 500e6, got {}",
+        mint_bank_msg
+    );
+    assert!(
+        mint_bank_msg <= Uint128::new(500_000_000),
+        "Mint amount must not exceed base 500e6, got {}",
+        mint_bank_msg
+    );
+}
+
 #[test]
 fn test_no_mint_when_amount_is_zero() {
     let mut deps = mock_dependencies(&[]);


### PR DESCRIPTION
…n tests

Aligns the docs and tests with the M-1 fix (commit a35c4e9... f75ad9a) that deferred `commit_pool_ordinal` allocation from create-time to threshold-cross-time.

Docs
- README.md: rewrote the mint-formula `x` definition (line 655) so it reflects the new "ordinal among pools that have CROSSED threshold" semantics, and updated the two anti-spam narrative blocks (lines 133, 561) to clarify that the 1h create cooldown + USD fee defend against registry bloat (not against ordinal inflation — the fix removes that vector entirely).

Stale comments
- factory/src/pool_creation_reply.rs:232: comment claimed the ordinal is "captured at create time" — false post-fix. Replaced with a description of the sentinel-then-overwrite flow.

Regression tests (NEW)
- test_commit_pool_ordinal_advances_on_threshold_cross_not_create: pins the core invariant — `Create` must not bump COMMIT_POOL_COUNTER; `NotifyThresholdCrossed` must.
- test_junk_creates_do_not_inflate_ordinal_for_legitimate_crosser: exercises the economic invariant — three junk creates from distinct attacker addresses must leave the counter at 0, and a legitimate pool that crosses afterward must receive ordinal 1 (with the mint amount in the undecayed-base range, confirming x=1 in the formula).

If either test fails in the future, the M-1 attack has regressed.

Test count: 250 → 252 (both new tests passing). Full factory suite passes; workspace compiles clean.

https://claude.ai/code/session_019mxdB2vwswjgipCUq2x4Fu