### PR TITLE
Enforce per-side MINIMUM_LIQUIDITY floor on first deposit (F-9)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -47,7 +47,7 @@ Low / Informational or by-design economic decisions.
 | F-6 | Low | creator-pool | Oracle staleness gate fail-opens when the factory returns `timestamp == 0`. **Open.** |
 | F-7 | Low | pool-core | `Simulation` / `CumulativePrices` queries price against live balances, not tracked reserves. **Open.** |
 | F-8 | Low (ops) | keepers | Default `ORACLE_POLL_INTERVAL_MS=330s` contradicts the on-chain 120s staleness gate. **Open.** |
-| F-9 | Low–Med | pool-core | First deposit with a highly asymmetric ratio can leave one reserve below `MINIMUM_LIQUIDITY` (stateful-fuzz invariant violation, pre-existing). **Open.** |
+| F-9 | Low–Med | pool-core | First deposit with a highly asymmetric ratio could leave one reserve below `MINIMUM_LIQUIDITY` (found via the stateful fuzz harness; pre-existing). **Fixed.** |
 | — | Info | various | Dead ungated oracle getters; doc/const mismatches; unbounded never-pruned maps; broken `optimize-pool` Makefile target; stale committed `*.wasm` blobs; "expand-economy" disburses from a pre-funded reservoir (not a literal mint). |
 
 Carried forward from the prior pre-audit (by-design / accepted, unchanged):
@@ -96,6 +96,23 @@ declared `(offer, ask)` are that pool's two real sides — before any funds
 move. `factory_addr` is now load-bearing. Regression tests:
 `router … route_through_unregistered_pool_rejected`,
 `route_with_mislabeled_pair_rejected`.
+
+### F-9 (Low–Medium) — First deposit could leave a reserve below MINIMUM_LIQUIDITY
+`packages/pool-core/src/liquidity_helpers.rs`
+
+`calc_liquidity_for_deposit` floored only the geometric mean
+(`sqrt(amount0·amount1) > MINIMUM_LIQUIDITY`) on the first deposit, so a
+highly asymmetric seed such as `(20, 500_000_000)` passed
+(`sqrt(20·5e8) = 100_000`) yet left `reserve0 = 20` — below the floor the swap
+path and `maybe_auto_pause_on_low_liquidity` both assume every live pool
+upholds, leaving the pool swap-broken on one side. Surfaced by the stateful
+fuzz harness (`minimum_liquidity_breached`); it predated and was not
+introduced by F-1/F-2.
+
+**Fix:** the genuinely-empty first deposit now requires BOTH credited amounts
+`≥ MINIMUM_LIQUIDITY`. Verified by the fuzz harness that found it (now green),
+a 3,000-case stateful run (clean), and a deterministic regression test
+(`standard-pool … first_deposit_rejects_subfloor_reserve_side`).
 
 ---
 
@@ -149,17 +166,6 @@ handlers.
 gate is 120s. Default-configured keepers leave commit valuations stale-blocked
 for most of each cycle. **Action:** lower the default to ≤90s.
 
-### F-9 — First deposit can leave a reserve below MINIMUM_LIQUIDITY
-Stateful fuzz (`fuzz-stateful`) flags `minimum_liquidity_breached` on a first
-`DepositLiquidity` with a highly asymmetric ratio (e.g. `amount0=20,
-amount1=500_000_000`): the liquidity check passes (`sqrt(20·5e8) ≫ 1000`) but
-`reserve0=20 < MINIMUM_LIQUIDITY`. The per-side reserve floor appears not to
-be enforced on the first deposit, so a pool can be created in a near-empty
-state on one side. **This is pre-existing** (reproduces on the clean tree; it
-is not introduced by the F-1/F-2 fixes). **Action:** enforce both reserves
-`≥ MINIMUM_LIQUIDITY` on the first deposit, or reject such deposits; then
-re-run the stateful fuzz harness.
-
 ---
 
 ## Verified clean (high-value confirmations)
@@ -196,7 +202,6 @@ re-run the stateful fuzz harness.
 
 1. **F-3 decision** — allowlist standard-pool tokens *or* correct the
    "hostile-CW20 safe" docs.
-2. **F-9** — close the first-deposit per-side reserve floor and re-fuzz.
-3. **F-5, F-6, F-8** — cheap fail-closed/hardening changes.
-4. **Pre-mainnet (non-code):** multisig/governance for the migrate+admin key
+2. **F-5, F-6, F-8** — cheap fail-closed/hardening changes.
+3. **Pre-mainnet (non-code):** multisig/governance for the migrate+admin key
    (I-1); a vesting decision on the unlocked creator allocation (M-1).

--- a/packages/pool-core/src/liquidity_helpers.rs
+++ b/packages/pool-core/src/liquidity_helpers.rs
@@ -448,6 +448,29 @@ pub fn calc_liquidity_for_deposit(
             return Err(ContractError::InsufficientLiquidity {});
         }
 
+        // First deposit into a genuinely empty pool must seed BOTH sides at
+        // or above the protocol reserve floor. A first deposit's reserves
+        // become exactly (final_amount0, final_amount1) (credited in
+        // `execute_deposit_liquidity`), and the geometric-mean check below
+        // is NOT sufficient on its own: a highly asymmetric seed such as
+        // (20, 500_000_000) yields raw_liquidity = sqrt(20·5e8) = 100_000,
+        // far above MINIMUM_LIQUIDITY, yet leaves reserve0 at 20 — below the
+        // floor that the swap path (which rejects reserves < MINIMUM_LIQUIDITY)
+        // and `maybe_auto_pause_on_low_liquidity` both assume every live pool
+        // upholds. Enforce the per-side floor here so a pool can never be
+        // created already sub-floor (and swap-broken) on one side.
+        if current_reserve0.is_zero()
+            && current_reserve1.is_zero()
+            && (final_amount0 < MINIMUM_LIQUIDITY || final_amount1 < MINIMUM_LIQUIDITY)
+        {
+            return Err(ContractError::Std(StdError::generic_err(format!(
+                "First deposit must seed both reserves at or above MINIMUM_LIQUIDITY ({}); \
+                 got ({}, {}). A sub-floor reserve would leave the pool swap-broken on one \
+                 side.",
+                MINIMUM_LIQUIDITY, final_amount0, final_amount1
+            ))));
+        }
+
         let product = final_amount0.checked_mul(final_amount1)?;
         let raw_liquidity = integer_sqrt(product).max(Uint128::new(1));
 

--- a/standard-pool/src/testing/deposit_liquidity.rs
+++ b/standard-pool/src/testing/deposit_liquidity.rs
@@ -232,6 +232,51 @@ fn deposit_rejects_zero_side_for_initial() {
     }
 }
 
+#[test]
+fn first_deposit_rejects_subfloor_reserve_side() {
+    // F-9 regression: an asymmetric first deposit whose geometric mean
+    // clears MINIMUM_LIQUIDITY but whose smaller side is below it must be
+    // rejected. sqrt(20 * 5e8) = 100_000 passes the geometric-mean check,
+    // yet reserve0 would be left at 20 — under the floor the swap path and
+    // auto-pause logic assume. The per-side floor must catch this.
+    let (mut deps, addrs) = instantiate_default_pool();
+
+    let user = addrs.pool_owner.clone();
+    let funds = vec![Coin::new(20u128, BLUECHIP_DENOM)];
+    let info = message_info(&user, &funds);
+    let err = execute(
+        deps.as_mut(),
+        mock_env(),
+        info,
+        ExecuteMsg::DepositLiquidity {
+            amount0: Uint128::new(20),
+            amount1: Uint128::new(500_000_000),
+            min_amount0: None,
+            min_amount1: None,
+            transaction_deadline: None,
+        },
+    )
+    .unwrap_err();
+
+    match err {
+        ContractError::Std(e) => {
+            assert!(
+                e.to_string()
+                    .contains("seed both reserves at or above MINIMUM_LIQUIDITY"),
+                "expected per-side floor error, got: {e}"
+            );
+        }
+        other => panic!("expected Std error, got {:?}", other),
+    }
+
+    // The deposit reverted before crediting any reserves.
+    let pool_state = POOL_STATE.load(&deps.storage).unwrap();
+    assert!(
+        pool_state.reserve0.is_zero() && pool_state.reserve1.is_zero(),
+        "rejected first deposit must not credit reserves"
+    );
+}
+
 // -- Slippage / ratio guards --------------------------------------------
 
 #[test]


### PR DESCRIPTION
calc_liquidity_for_deposit floored only the geometric mean (sqrt(amount0*amount1)) on the first deposit into an empty pool, so a highly asymmetric seed such as (20, 500_000_000) passed (sqrt = 100_000 >> MINIMUM_LIQUIDITY) yet left reserve0 at 20 — below the floor the swap path and maybe_auto_pause_on_low_liquidity both assume every live pool upholds, leaving the pool swap-broken on one side. The stateful fuzz harness surfaced this as minimum_liquidity_breached; it predated the F-1/F-2 fixes.

The genuinely-empty first deposit now requires both credited amounts
>= MINIMUM_LIQUIDITY. Adds a deterministic regression test
(first_deposit_rejects_subfloor_reserve_side); the fuzz harness that found it is now green and a 3,000-case stateful run is clean. Updates SECURITY_AUDIT.md to mark F-9 fixed.