### PR TITLE
Fix router simulation/spread bugs; harden ops per deployment testing

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,151 @@
+# BlueChip Production Runbook
+
+How to operate this stack in production. The key mental split: the
+**router** and **expand-economy** are *passive* contracts — they need
+governance and funding, not babysitting. The **oracle pipeline** is
+*active* — three recurring jobs that, if any one stops, make the whole
+protocol **fail closed**: commits and pool creation start reverting
+within minutes. Money never moves incorrectly when your infra dies; it
+just stops moving until someone calls the permissionless entry points
+again. That property is deliberate (bounties, permissionless recovery,
+fail-closed gates) — operate to it.
+
+All constants below are quoted from source; paths given so they can be
+re-verified after any contract change.
+
+## The timing constants that matter
+
+| Constant | Value | Where | Meaning |
+|---|---|---|---|
+| `UPDATE_INTERVAL` | **60 s** | `factory/src/internal_bluechip_price_oracle.rs` | Minimum gap between oracle publishing rounds — `update_oracle_price` is permissionless but rate-limited to this |
+| `MAX_ORACLE_STALENESS_SECONDS` | **120 s** | `creator-pool/src/swap_helper.rs` | Pool-side gate: commit valuation rejects once the published price is older than this. **This is the gate users hit first.** |
+| `MAX_PRICE_AGE_SECONDS_BEFORE_STALE` | **300 s** | `factory/src/state.rs` | Factory-side gate on the *Pyth data* the oracle consumes |
+| Distribution stall timeout | 24 h | `creator-pool` (`DISTRIBUTION_STALL_TIMEOUT_SECONDS`) | After this, batches reject and admin recovery is required |
+| Public distribution recovery | 7 days | `creator-pool` (`SelfRecoverDistribution`) | Anyone may restart a stalled distribution after this |
+| Admin config changes | 48 h | factory / router / expand-economy timelocks | Every propose→apply pair needs calendared two-step execution |
+
+> The 120 s pool gate is `UPDATE_INTERVAL + 60 s` grace. **Run oracle
+> keepers at a 65–75 s cadence** — a single missed round leaves ~60 s of
+> slack before commits fail; two missed rounds is an outage.
+
+## The three recurring jobs (the oracle pipeline)
+
+### 1. Pyth pusher
+The factory only trusts Pyth data younger than 300 s (and older than a
+10 s anti-MEV floor). Someone must keep submitting VAAs to the Pyth
+contract. On mainnet, run **Pyth's official `price-pusher`** against
+mainnet Hermes — it handles fee bumps, deviation-triggered pushes, and
+retries. Budget: Pyth update fee + gas, continuously, forever. Do not
+assume another protocol on the chain pushes your feed.
+
+### 2. Oracle keeper (`update_oracle_price`)
+Permissionless, rate-limited to one publishing round per 60 s. If it
+stops, the published price ages past 120 s and every price-dependent
+path reverts. Run `keepers/` (`npm run oracle-keeper`) at 65–75 s
+cadence with retry. **Fund `SetOracleUpdateBounty`** so independent
+keepers get paid for successful rounds — your bots are the primary, the
+bounty market is the redundancy layer.
+
+### 3. Anchor activity
+The oracle only publishes when the anchor pool's price accumulator
+advanced between snapshots — a round with zero anchor swaps records a
+snapshot but publishes nothing, and enough quiet rounds in a row means
+staleness. Organic volume normally provides this. During dead hours
+either (a) accept fail-closed during inactivity — the code treats this
+as intended pressure — or (b) run a small heartbeat bot doing
+alternating micro-swaps on the anchor pool. The heartbeat costs gas +
+LP commission on tiny notional; recognize it as an ongoing subsidy
+masking low liquidity, and make its discontinuation a conscious
+decision, not an accident.
+
+## Event-driven keeper duties
+
+Both live in `keepers/` (`npm run distribution-keeper`) and now
+**auto-discover every commit pool from the factory's `pools` registry
+query** — leave `POOL_ADDRESSES` unset and new pools are picked up
+automatically; set it only to pin a subset.
+
+- **`continue_distribution`** — a threshold cross pays nobody in the
+  crossing tx; recipients are flushed in gas-budgeted batches by keeper
+  calls until `distribution_state` clears. Fund `SetDistributionBounty`
+  for third-party backstop. Alert on `distribution_state.is_stalled`
+  (24 h timeout → `RecoverPoolStuckStates` from the factory admin;
+  after 7 days anyone can `self_recover_distribution`).
+- **`retry_factory_notify`** — the factory notification at threshold
+  cross is deliberately deferred-on-error. The keeper checks
+  `factory_notify_status` and retries while `pending: true`
+  (permissionless, idempotent — the factory's `POOL_THRESHOLD_MINTED`
+  gate makes double-mints impossible). Retries that keep failing are an
+  ops page; the classic root cause is a misconfigured expand-economy.
+
+## The passive contracts
+
+**Router** — no bot needed. Put its admin behind a multisig, and
+monitor for unexpected `propose_config_update` events (48 h timelock
+gives you the reaction window). The three issues found in deployment
+testing are fixed in this repo: simulation now resolves each hop
+against the factory registry (standard-pool hops work), pool
+simulations quote from `POOL_STATE` accounting reserves instead of
+contract balances (no more optimistic quotes), and the router pins each
+hop's `max_spread` to the pools' 5% hard cap so `minimum_receive` is
+the binding slippage control.
+
+**Expand-economy** — two duties:
+1. It must be instantiated with `factory_address` = the **factory
+   contract**. The contract now rejects instantiation when
+   `factory_address` equals the instantiating wallet (the placeholder
+   footgun), and `scripts/verify_deploy.sh` cross-checks the wiring in
+   both directions. Correct deploy order: factory first
+   (`bluechip_mint_contract_address: null`) → expand-economy pointing
+   at the factory → factory `ProposeConfigUpdate` to set the mint
+   address → 48 h later, apply — **before** opening pool creation.
+2. Keep it funded in bluechip. Every threshold cross pays rewards from
+   its balance (up to ~500 BC per cross at default config, decaying);
+   if it runs dry, crossings start deferring notifies. Alert on its
+   balance like keeper gas.
+
+## Infrastructure rules
+
+- **Supervision, not terminals.** Every bot under systemd
+  (`Restart=always`) or a k8s deployment. A keeper that dies with an
+  SSH session means a stale oracle within ~2 minutes.
+- **One dedicated key per bot**, never shared with admin/treasury —
+  two processes signing with one key produce account-sequence races.
+  Keep balances low, auto-refill from treasury, alert below threshold.
+- **RPC redundancy**: primary + fallback endpoints in every bot;
+  ideally run your own node.
+- **Post-deploy verification**: run `scripts/verify_deploy.sh` after
+  every deploy and after every timelocked config change lands.
+
+## Monitoring
+
+**The single best health probe:** query
+`{"internal_blue_chip_oracle_query":{"get_bluechip_usd_price":{}}}` on
+the factory every minute; page if it errors **or** the returned
+`timestamp` is older than 120 s. Because the system fails closed, this
+one probe transitively proves the Pyth pusher, the oracle keeper, and
+anchor activity are all alive. (`verify_deploy.sh` performs exactly
+this check; the block explorer's ops strip surfaces it too.)
+
+Secondary alerts:
+- Pyth `publish_time` age at the Pyth contract
+- per-bot wallet balances
+- expand-economy bluechip balance (`get_balance`)
+- any pool with `factory_notify_status.pending == true` for > 1 h
+- any pool with `distribution_state.is_stalled == true`
+- unexpected `propose_config_update` events on factory / router /
+  expand-economy (the 48 h timelock is your reaction window)
+
+## Reference topology
+
+Two oracle-keeper bots in different regions + funded on-chain bounties
+as the third layer; one official Pyth price-pusher; one
+distribution/notify watcher (auto-discovering); the price-query canary
+in your monitoring stack. Four small processes and a dashboard.
+
+## Governance hygiene
+
+Factory admin, router admin, expand-economy owner → multisig. Every
+admin action is 48 h propose→apply: calendar both steps, monitor the
+pending-proposal state between them, and treat an unexpected pending
+proposal as an incident.

--- a/creator-pool/src/testing/query_tests.rs
+++ b/creator-pool/src/testing/query_tests.rs
@@ -690,3 +690,53 @@ fn last_commited_query_accepts_both_spellings() {
         }
     }
 }
+
+#[test]
+fn simulation_prices_against_accounting_reserves_not_balances() {
+    // Regression: simulations used to derive reserves from the
+    // contract's bank/cw20 BALANCES, which on commit pools also hold
+    // LP fee reserves, the creator fee pot, and commit proceeds —
+    // inflating quoted depth so execution undershoots the quote. The
+    // quote must come from POOL_STATE, the reserves execution trades
+    // against.
+    let mut deps = setup_pool_with_querier();
+
+    // Drive the accounting reserves away from the bank/cw20 balances the
+    // querier was seeded with. If the simulation still read balances,
+    // the quote below would not match the POOL_STATE-derived expectation.
+    let mut pool_state = crate::state::POOL_STATE.load(&deps.storage).unwrap();
+    pool_state.reserve0 = Uint128::new(10_000_000_000);
+    pool_state.reserve1 = Uint128::new(100_000_000_000);
+    crate::state::POOL_STATE
+        .save(&mut deps.storage, &pool_state)
+        .unwrap();
+    let pool_specs = crate::state::POOL_SPECS.load(&deps.storage).unwrap();
+    let offer_amount = Uint128::new(1_000_000_000);
+    let (expected_return, expected_spread, expected_commission) =
+        crate::swap_helper::compute_swap(
+            pool_state.reserve0,
+            pool_state.reserve1,
+            offer_amount,
+            pool_specs.lp_fee,
+        )
+        .unwrap();
+
+    let res = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::Simulation {
+            offer_asset: TokenInfo {
+                info: TokenType::Native {
+                    denom: "ubluechip".to_string(),
+                },
+                amount: offer_amount,
+            },
+        },
+    )
+    .unwrap();
+    let resp: SimulationResponse = from_json(res).unwrap();
+
+    assert_eq!(resp.return_amount, expected_return);
+    assert_eq!(resp.spread_amount, expected_spread);
+    assert_eq!(resp.commission_amount, expected_commission);
+}

--- a/expand-economy/src/contract.rs
+++ b/expand-economy/src/contract.rs
@@ -47,8 +47,18 @@ pub fn instantiate(
     // later via the timelocked propose / apply path.
     validate_native_denom(&bluechip_denom)?;
 
+    let factory_address = deps.api.addr_validate(&msg.factory_address)?;
+    // The exact misconfiguration observed in deployment testing:
+    // pointing factory_address at the deployer wallet as a "placeholder".
+    // RequestExpansion gates on this address, so every threshold-crossing
+    // mint then fails (deferred notifies) until a 48h-timelocked config
+    // update lands. A wallet can never be the factory — fail fast here.
+    if factory_address == info.sender {
+        return Err(ContractError::FactoryAddressIsInstantiator {});
+    }
+
     let config = Config {
-        factory_address: deps.api.addr_validate(&msg.factory_address)?,
+        factory_address,
         owner: deps
             .api
             .addr_validate(&msg.owner.unwrap_or_else(|| info.sender.to_string()))?,

--- a/expand-economy/src/error.rs
+++ b/expand-economy/src/error.rs
@@ -26,6 +26,14 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
+    #[error(
+        "factory_address must be the factory CONTRACT, not the instantiating wallet. \
+         Deploy the factory first (bluechip_mint_contract_address: null), then instantiate \
+         expand-economy pointing at it — a placeholder here costs a 48h timelock to repair \
+         and defers every threshold-crossing reward until fixed"
+    )]
+    FactoryAddressIsInstantiator {},
+
     #[error("Daily expansion cap exceeded: requested {requested}, already spent {spent_in_window} in current 24h window, cap {cap}")]
     DailyExpansionCapExceeded {
         requested: Uint128,

--- a/expand-economy/src/tests.rs
+++ b/expand-economy/src/tests.rs
@@ -275,3 +275,25 @@ mod expand_economy_tests {
         assert_eq!("ucustom2", value.bluechip_denom);
     }
 }
+
+#[test]
+fn instantiate_rejects_factory_address_equal_to_sender() {
+    let mut deps = cosmwasm_std::testing::mock_dependencies();
+    let deployer = cosmwasm_std::testing::MockApi::default().addr_make("deployer");
+    let msg = crate::msg::InstantiateMsg {
+        factory_address: deployer.to_string(),
+        owner: None,
+        bluechip_denom: None,
+    };
+    let err = crate::contract::instantiate(
+        deps.as_mut(),
+        cosmwasm_std::testing::mock_env(),
+        cosmwasm_std::testing::message_info(&deployer, &[]),
+        msg,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::error::ContractError::FactoryAddressIsInstantiator {}
+    ));
+}

--- a/keepers/src/__tests__/discovery.test.ts
+++ b/keepers/src/__tests__/discovery.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { discoverCommitPools, resolveWatchList } from "../lib/discovery.js";
+
+const FACTORY = "bluechip1factory";
+
+function querierFromPages(pages: Array<Array<{ pool_id: number; pool_addr: string; pool_kind: "commit" | "standard" }>>) {
+  let call = 0;
+  return {
+    calls: [] as Array<Record<string, unknown>>,
+    async queryContractSmart<T>(_c: string, msg: Record<string, unknown>): Promise<T> {
+      (this.calls as Array<Record<string, unknown>>).push(msg);
+      const page = pages[Math.min(call, pages.length - 1)] ?? [];
+      call += 1;
+      return { pools: page } as T;
+    },
+  };
+}
+
+describe("pool discovery", () => {
+  it("filters to commit pools and pages with start_after", async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      pool_id: i + 1,
+      pool_addr: `bluechip1pool_${i + 1}`,
+      pool_kind: (i % 2 === 0 ? "commit" : "standard") as "commit" | "standard",
+    }));
+    const lastPage = [
+      { pool_id: 101, pool_addr: "bluechip1pool_101", pool_kind: "commit" as const },
+    ];
+    const q = querierFromPages([fullPage, lastPage]);
+
+    const pools = await discoverCommitPools(q, FACTORY);
+    expect(pools).toHaveLength(51); // 50 commit pools in page 1 + 1 in page 2
+    expect(pools).toContain("bluechip1pool_101");
+    expect(pools).not.toContain("bluechip1pool_2"); // standard, excluded
+    // Page 2 must resume after the last pool_id of page 1.
+    expect(q.calls[1]).toEqual({ pools: { start_after: 100, limit: 100 } });
+  });
+
+  it("resolveWatchList prefers the static list and survives discovery failure", async () => {
+    const failing = {
+      async queryContractSmart<T>(): Promise<T> {
+        throw new Error("rpc down");
+      },
+    };
+    // Static list wins without touching the chain.
+    expect(await resolveWatchList(failing, FACTORY, ["bluechip1pinned"], [])).toEqual([
+      "bluechip1pinned",
+    ]);
+    // Discovery failure keeps the previous good list instead of blanking it.
+    expect(await resolveWatchList(failing, FACTORY, [], ["bluechip1last_good"])).toEqual([
+      "bluechip1last_good",
+    ]);
+  });
+});

--- a/keepers/src/distribution-keeper.ts
+++ b/keepers/src/distribution-keeper.ts
@@ -4,6 +4,7 @@ import { buildKeeperClient } from "./lib/client.js";
 import { nextDistributionSleepMs } from "./lib/decisions.js";
 import { runDistributionSweep } from "./lib/distribution-loop.js";
 import { checkFactoryBalance, checkKeeperBalance } from "./lib/oracle-loop.js";
+import { resolveWatchList } from "./lib/discovery.js";
 import { runRetryNotifySweep } from "./lib/retry-notify-loop.js";
 import { interruptibleSleep } from "./lib/sleep.js";
 import { log } from "./lib/logger.js";
@@ -12,9 +13,9 @@ async function main(): Promise<void> {
   const cfg = loadConfigFromEnv();
 
   if (cfg.POOL_ADDRESSES.length === 0) {
-    log.error("POOL_ADDRESSES is empty — nothing for the distribution keeper to watch");
-    log.error("set POOL_ADDRESSES in .env as a comma-separated list of pool contract addresses");
-    process.exit(1);
+    log.info(
+      "POOL_ADDRESSES is empty — auto-discovering commit pools from the factory registry each sweep",
+    );
   }
 
   log.info("distribution keeper starting", {
@@ -34,7 +35,15 @@ async function main(): Promise<void> {
   process.on("SIGINT", stop);
   process.on("SIGTERM", stop);
 
+  let watchList: string[] = cfg.POOL_ADDRESSES;
   while (!stopped) {
+    watchList = await resolveWatchList(
+      client,
+      cfg.FACTORY_ADDRESS,
+      cfg.POOL_ADDRESSES,
+      watchList,
+    );
+
     // Run the retry-factory-notify sweep BEFORE the distribution sweep.
     // Order matters: a stuck factory-notify means POOL_THRESHOLD_MINTED
     // never landed on the factory side, which blocks the bluechip
@@ -45,11 +54,11 @@ async function main(): Promise<void> {
     // RetryFactoryNotify is itself permissionless and idempotent on
     // the factory side (POOL_THRESHOLD_MINTED gate), so a redundant
     // call is at worst wasted gas — never a double-mint.
-    await runRetryNotifySweep(client, cfg.POOL_ADDRESSES);
+    await runRetryNotifySweep(client, watchList);
 
     const { madeProgress } = await runDistributionSweep(
       client,
-      cfg.POOL_ADDRESSES,
+      watchList,
       cfg.DISTRIBUTION_PER_POOL_DELAY_MS,
     );
     await checkKeeperBalance(client, cfg.GAS_DENOM, cfg.MIN_KEEPER_BALANCE_UBLUECHIP);

--- a/keepers/src/lib/discovery.ts
+++ b/keepers/src/lib/discovery.ts
@@ -1,0 +1,74 @@
+import { log } from "./logger.js";
+
+// Pool auto-discovery via the factory's paginated `pools` registry
+// query. Replaces the hand-maintained POOL_ADDRESSES list: a keeper
+// pointed at the factory automatically picks up every commit pool,
+// including ones created after the keeper started. Standard pools are
+// excluded — they have no commit phase, so there is never a
+// distribution to flush or a factory notify to retry on them.
+
+interface PoolListEntry {
+  pool_id: number;
+  pool_addr: string;
+  pool_kind: "commit" | "standard";
+}
+
+interface PoolsResponse {
+  pools: PoolListEntry[];
+}
+
+interface SmartQuerier {
+  queryContractSmart<T>(contract: string, msg: Record<string, unknown>): Promise<T>;
+}
+
+const PAGE_LIMIT = 100;
+const MAX_PAGES = 50;
+
+export async function discoverCommitPools(
+  client: SmartQuerier,
+  factoryAddress: string,
+): Promise<string[]> {
+  const found: string[] = [];
+  let startAfter: number | null = null;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const res: PoolsResponse = await client.queryContractSmart<PoolsResponse>(factoryAddress, {
+      pools: { start_after: startAfter, limit: PAGE_LIMIT },
+    });
+    for (const p of res.pools) {
+      if (p.pool_kind === "commit") found.push(p.pool_addr);
+    }
+    if (res.pools.length < PAGE_LIMIT) break;
+    startAfter = res.pools[res.pools.length - 1]!.pool_id;
+  }
+  return found;
+}
+
+// Resolve the watch list for one sweep: an explicit POOL_ADDRESSES env
+// list wins (lets operators pin a subset); otherwise discover from the
+// factory registry. Discovery failures fall back to the last good list
+// so a flaky RPC round doesn't blank out the watch set mid-flight.
+export async function resolveWatchList(
+  client: SmartQuerier,
+  factoryAddress: string,
+  staticList: string[],
+  lastGood: string[],
+): Promise<string[]> {
+  if (staticList.length > 0) return staticList;
+  try {
+    const discovered = await discoverCommitPools(client, factoryAddress);
+    if (discovered.length !== lastGood.length) {
+      log.info("pool discovery updated watch list", {
+        pools: discovered.length,
+        previously: lastGood.length,
+      });
+    }
+    return discovered;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.warn("pool discovery failed — keeping previous watch list", {
+      detail,
+      pools: lastGood.length,
+    });
+    return lastGood;
+  }
+}

--- a/packages/pool-core/src/query.rs
+++ b/packages/pool-core/src/query.rs
@@ -42,32 +42,31 @@ pub fn query_pair_info(deps: Deps) -> StdResult<PoolDetails> {
     Ok(pool_info.pool_info)
 }
 
+/// Quote against POOL_STATE's accounting reserves — the exact values
+/// `execute_simple_swap` trades against — NOT the contract's bank/cw20
+/// balances. Balances also hold non-AMM funds (LP fee reserves, the
+/// creator fee pot, pre-threshold commit proceeds, emergency escrow),
+/// so a balance-based quote overstates depth and returns optimistic
+/// amounts that execution then undershoots.
 pub fn query_simulation(deps: Deps, offer_asset: TokenInfo) -> StdResult<SimulationResponse> {
     let pool_info = POOL_INFO.load(deps.storage)?;
     let pool_specs = POOL_SPECS.load(deps.storage)?;
-    let contract_addr = pool_info.pool_info.contract_addr.clone();
+    let pool_state = POOL_STATE.load(deps.storage)?;
 
-    let pools: [TokenInfo; 2] = pool_info
-        .pool_info
-        .query_pools(&deps.querier, contract_addr)?;
-
-    let offer_pool: TokenInfo;
-    let ask_pool: TokenInfo;
-    if offer_asset.info.equal(&pools[0].info) {
-        offer_pool = pools[0].clone();
-        ask_pool = pools[1].clone();
-    } else if offer_asset.info.equal(&pools[1].info) {
-        offer_pool = pools[1].clone();
-        ask_pool = pools[0].clone();
+    let infos = &pool_info.pool_info.asset_infos;
+    let (offer_reserve, ask_reserve) = if offer_asset.info.equal(&infos[0]) {
+        (pool_state.reserve0, pool_state.reserve1)
+    } else if offer_asset.info.equal(&infos[1]) {
+        (pool_state.reserve1, pool_state.reserve0)
     } else {
         return Err(StdError::generic_err(
             "Given offer asset does not belong in the pair",
         ));
-    }
+    };
 
     let (return_amount, spread_amount, commission_amount) = compute_swap(
-        offer_pool.amount,
-        ask_pool.amount,
+        offer_reserve,
+        ask_reserve,
         offer_asset.amount,
         pool_specs.lp_fee,
     )?;
@@ -85,29 +84,24 @@ pub fn query_reverse_simulation(
 ) -> StdResult<ReverseSimulationResponse> {
     let pool_info = POOL_INFO.load(deps.storage)?;
     let pool_specs = POOL_SPECS.load(deps.storage)?;
-    let contract_addr = pool_info.pool_info.contract_addr.clone();
+    let pool_state = POOL_STATE.load(deps.storage)?;
 
-    let pools: [TokenInfo; 2] = pool_info
-        .pool_info
-        .query_pools(&deps.querier, contract_addr)?;
-
-    let offer_pool: TokenInfo;
-    let ask_pool: TokenInfo;
-    if ask_asset.info.equal(&pools[0].info) {
-        ask_pool = pools[0].clone();
-        offer_pool = pools[1].clone();
-    } else if ask_asset.info.equal(&pools[1].info) {
-        ask_pool = pools[1].clone();
-        offer_pool = pools[0].clone();
+    // Same accounting-reserve sourcing as `query_simulation` — see the
+    // doc-comment there.
+    let infos = &pool_info.pool_info.asset_infos;
+    let (offer_reserve, ask_reserve) = if ask_asset.info.equal(&infos[0]) {
+        (pool_state.reserve1, pool_state.reserve0)
+    } else if ask_asset.info.equal(&infos[1]) {
+        (pool_state.reserve0, pool_state.reserve1)
     } else {
         return Err(StdError::generic_err(
             "Given ask asset doesn't belong to pairs",
         ));
-    }
+    };
 
     let (offer_amount, spread_amount, commission_amount) = compute_offer_amount(
-        offer_pool.amount,
-        ask_pool.amount,
+        offer_reserve,
+        ask_reserve,
         ask_asset.amount,
         pool_specs.lp_fee,
     )?;

--- a/router/src/execution.rs
+++ b/router/src/execution.rs
@@ -35,8 +35,9 @@
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{
-    from_json, to_json_binary, Addr, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
-    Reply, ReplyOn, Response, StdError, SubMsg, SubMsgResult, Timestamp, Uint128, WasmMsg,
+    from_json, to_json_binary, Addr, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
+    MessageInfo, Reply, ReplyOn, Response, StdError, SubMsg, SubMsgResult, Timestamp, Uint128,
+    WasmMsg,
 };
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use pool_factory_interfaces::asset::{TokenInfo, TokenType};
@@ -467,11 +468,23 @@ pub fn validate_route(operations: &[SwapOperation]) -> Result<(), RouterError> {
     Ok(())
 }
 
-/// Builds the underlying pool swap message for one hop. Per-hop
-/// slippage gates (`belief_price`, `max_spread`) are intentionally
-/// pinned to `None` here — see the module / `ExecuteMsg` doc-comment
-/// for why they cannot be made meaningful across heterogeneous
-/// multi-hop pairs. End-to-end slippage is enforced via
+/// Per-hop `max_spread` forwarded to every underlying pool call. A
+/// `None` here would NOT disable the gate — pools substitute their
+/// 0.5% `DEFAULT_SLIPPAGE`, which silently failed every thin-pool
+/// route regardless of the caller's `minimum_receive`. Pinning the
+/// pools' 5% hard cap (the widest value accepted without
+/// `allow_high_max_spread`) neutralizes the per-hop gate so
+/// `minimum_receive` in `execute_assert_received` is the binding,
+/// end-to-end slippage control — exactly the model the `ExecuteMsg`
+/// docs promise.
+fn per_hop_max_spread() -> Decimal {
+    Decimal::percent(5)
+}
+
+/// Builds the underlying pool swap message for one hop. `belief_price`
+/// stays `None` (meaningless across heterogeneous multi-hop pairs);
+/// `max_spread` is pinned to the pools' hard cap — see
+/// [`per_hop_max_spread`]. End-to-end slippage is enforced via
 /// `minimum_receive` in `execute_assert_received`.
 fn build_pool_swap_msg(
     operation: &SwapOperation,
@@ -486,7 +499,7 @@ fn build_pool_swap_msg(
                     amount: offer_amount,
                 },
                 belief_price: None,
-                max_spread: None,
+                max_spread: Some(per_hop_max_spread()),
                 to: Some(to),
                 transaction_deadline: None,
             };
@@ -502,7 +515,7 @@ fn build_pool_swap_msg(
         TokenType::CreatorToken { contract_addr } => {
             let hook = PoolSwapCw20HookMsg::Swap {
                 belief_price: None,
-                max_spread: None,
+                max_spread: Some(per_hop_max_spread()),
                 to: Some(to),
                 transaction_deadline: None,
             };

--- a/router/src/msg.rs
+++ b/router/src/msg.rs
@@ -35,9 +35,12 @@ pub struct InstantiateMsg {
 /// final ask token, NOT via per-hop `belief_price` / `max_spread`. A
 /// single per-pair belief price is meaningless across hops on heterogeneous
 /// pairs (units differ between `A/bluechip` and `bluechip/B`), so the
-/// router does not accept those parameters and always passes `None` for
-/// them on the underlying pool calls. Frontends should size
-/// `minimum_receive` from the simulation result (see `SimulateMultiHop`).
+/// router does not accept those parameters. On the underlying pool calls
+/// it passes `belief_price = None` and pins `max_spread` to the pools'
+/// 5% hard cap — passing `None` would make pools substitute their 0.5%
+/// default and silently gate every thin-pool hop regardless of the
+/// caller's tolerance. Frontends should size `minimum_receive` from the
+/// simulation result (see `SimulateMultiHop`).
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Run a multi-hop swap whose first hop offers the native bluechip

--- a/router/src/simulation.rs
+++ b/router/src/simulation.rs
@@ -6,26 +6,35 @@
 //! the executor will and chains each pool's `Simulation` output into
 //! the next hop's input.
 //!
-//! Cost: two pool queries per hop (`IsFullyCommited` + `Simulation`),
-//! capped at six queries for a maximum-length route. No storage I/O.
+//! Cost: up to three queries per hop (factory registry lookup,
+//! `IsFullyCommited` on commit pools only, `Simulation`), capped at
+//! nine for a maximum-length route. One CONFIG storage read.
 
 use cosmwasm_std::{to_json_binary, Decimal, Deps, QueryRequest, StdError, Uint128, WasmQuery};
 use pool_factory_interfaces::asset::TokenInfo;
 use pool_factory_interfaces::routing::{
-    PoolSwapQueryMsg, RouterPoolCommitStatus, RouterSwapSimulationResponse, SwapOperation,
+    FactoryRouteQueryMsg, PoolSwapQueryMsg, RouterPoolCommitStatus,
+    RouterSwapSimulationResponse, SwapOperation,
 };
+use pool_factory_interfaces::{PoolKind, RegisteredPoolResponse};
 
 use crate::error::RouterError;
 use crate::execution::validate_route;
 use crate::msg::SimulateMultiHopResponse;
+use crate::state::CONFIG;
 
 /// Simulate a multi-hop route end to end.
 ///
 /// For each hop the simulation
-/// 1. queries `IsFullyCommited` and rejects if the pool is still in its
-/// pre-threshold commit phase, so frontends never render a silent
-/// zero result for a route that cannot yet execute, and
-/// 2. queries the pool's `Simulation` with the current chained input
+/// 1. resolves the pool against the factory registry — mirroring
+/// execution's `validate_route_pools_registered`, and the only way to
+/// learn the pool's kind without trusting the caller,
+/// 2. for COMMIT pools only, queries `IsFullyCommited` and rejects if
+/// the pool is still in its pre-threshold phase, so frontends never
+/// render a silent zero result for a route that cannot yet execute.
+/// (Standard pools do not implement this query — sending it
+/// unconditionally made every standard-pool hop error out.)
+/// 3. queries the pool's `Simulation` with the current chained input
 /// and uses the returned amount as the next hop's input.
 ///
 /// Price impact is reported as `1 - product(per_hop_survival)` where
@@ -45,23 +54,38 @@ pub fn simulate_multi_hop(
     }
     validate_route(&operations)?;
 
+    let config = CONFIG.load(deps.storage)?;
     let mut current_input = offer_amount;
     let mut intermediate_amounts: Vec<Uint128> = Vec::with_capacity(operations.len());
     let mut survival = Decimal::one();
 
     for (idx, op) in operations.iter().enumerate() {
-        let commit_status: RouterPoolCommitStatus =
+        let registered: Option<RegisteredPoolResponse> =
             deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
-                contract_addr: op.pool_addr.clone(),
-                msg: to_json_binary(&PoolSwapQueryMsg::IsFullyCommited {})?,
+                contract_addr: config.factory_addr.to_string(),
+                msg: to_json_binary(&FactoryRouteQueryMsg::PoolByAddress {
+                    pool_addr: op.pool_addr.clone(),
+                })?,
             }))?;
-        if let RouterPoolCommitStatus::InProgress { raised, target } = commit_status {
-            return Err(RouterError::PoolInCommitPhase {
-                hop_index: idx,
-                pool_addr: op.pool_addr.clone(),
-                raised,
-                target,
-            });
+        let pool = registered.ok_or_else(|| RouterError::PoolNotRegistered {
+            hop_index: idx,
+            pool_addr: op.pool_addr.clone(),
+        })?;
+
+        if pool.pool_kind == PoolKind::Commit {
+            let commit_status: RouterPoolCommitStatus =
+                deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+                    contract_addr: op.pool_addr.clone(),
+                    msg: to_json_binary(&PoolSwapQueryMsg::IsFullyCommited {})?,
+                }))?;
+            if let RouterPoolCommitStatus::InProgress { raised, target } = commit_status {
+                return Err(RouterError::PoolInCommitPhase {
+                    hop_index: idx,
+                    pool_addr: op.pool_addr.clone(),
+                    raised,
+                    target,
+                });
+            }
         }
 
         let sim: RouterSwapSimulationResponse =

--- a/router/src/testing/integration_tests.rs
+++ b/router/src/testing/integration_tests.rs
@@ -17,6 +17,7 @@ use cw_multi_test::{
 };
 use pool_factory_interfaces::asset::TokenType;
 use pool_factory_interfaces::routing::SwapOperation;
+use pool_factory_interfaces::PoolKind;
 
 use crate::contract;
 use crate::msg::{
@@ -51,11 +52,13 @@ struct World {
     creator_a: Addr,
     creator_b: Addr,
     creator_c: Addr,
+    creator_std: Addr,
     pool_a: Addr,
     pool_b: Addr,
     pool_c: Addr,
     pool_uncommitted: Addr,
     pool_empty: Addr,
+    pool_std: Addr,
 }
 
 fn router_contract() -> Box<dyn Contract<Empty>> {
@@ -151,6 +154,8 @@ fn setup_world() -> World {
     );
     let creator_empty =
         instantiate_creator_token(&mut app, cw20_code, &admin, &user, "Creator Empty", "CRE");
+    let creator_std =
+        instantiate_creator_token(&mut app, cw20_code, &admin, &user, "Creator Std", "CRS");
 
     let pool_a = instantiate_pool(&mut app, pool_code, &admin, &creator_a, true, true);
     let pool_b = instantiate_pool(&mut app, pool_code, &admin, &creator_b, true, true);
@@ -164,6 +169,10 @@ fn setup_world() -> World {
         true,
     );
     let pool_empty = instantiate_pool(&mut app, pool_code, &admin, &creator_empty, true, false);
+    // A standard pool: real ones reject the commit-only IsFullyCommited
+    // query, which the mock reproduces when `standard: true`.
+    let pool_std =
+        instantiate_standard_pool(&mut app, pool_code, &admin, &creator_std);
 
     // Stand up the mock factory with every pool registered against its
     // canonical pair, then point the router at it. The router queries this
@@ -178,22 +187,32 @@ fn setup_world() -> World {
                     mock_factory::RegistryEntry {
                         pool_addr: pool_a.to_string(),
                         pool_token_info: pool_pair(&creator_a),
+                        pool_kind: PoolKind::Commit,
                     },
                     mock_factory::RegistryEntry {
                         pool_addr: pool_b.to_string(),
                         pool_token_info: pool_pair(&creator_b),
+                        pool_kind: PoolKind::Commit,
                     },
                     mock_factory::RegistryEntry {
                         pool_addr: pool_c.to_string(),
                         pool_token_info: pool_pair(&creator_c),
+                        pool_kind: PoolKind::Commit,
                     },
                     mock_factory::RegistryEntry {
                         pool_addr: pool_uncommitted.to_string(),
                         pool_token_info: pool_pair(&creator_uncommitted),
+                        pool_kind: PoolKind::Commit,
                     },
                     mock_factory::RegistryEntry {
                         pool_addr: pool_empty.to_string(),
                         pool_token_info: pool_pair(&creator_empty),
+                        pool_kind: PoolKind::Commit,
+                    },
+                    mock_factory::RegistryEntry {
+                        pool_addr: pool_std.to_string(),
+                        pool_token_info: pool_pair(&creator_std),
+                        pool_kind: PoolKind::Standard,
                     },
                 ],
             },
@@ -226,11 +245,13 @@ fn setup_world() -> World {
         creator_a,
         creator_b,
         creator_c,
+        creator_std,
         pool_a,
         pool_b,
         pool_c,
         pool_uncommitted,
         pool_empty,
+        pool_std,
     }
 }
 
@@ -294,6 +315,7 @@ fn instantiate_pool(
                     },
                 ],
                 fully_committed,
+                standard: false,
             },
             &[],
             "mock_pool",
@@ -318,6 +340,56 @@ fn instantiate_pool(
         )
         .unwrap();
     }
+    pool
+}
+
+/// Same shape as [`instantiate_pool`] but in standard-pool mode: the
+/// mock rejects the commit-only `IsFullyCommited` query exactly like a
+/// real standard pool, and reserves are always seeded (standard pools
+/// are tradeable from instantiation).
+fn instantiate_standard_pool(
+    app: &mut TestApp,
+    code_id: u64,
+    admin: &Addr,
+    creator: &Addr,
+) -> Addr {
+    let pool = app
+        .instantiate_contract(
+            code_id,
+            admin.clone(),
+            &mock_pool::InstantiateMsg {
+                asset_infos: [
+                    TokenType::Native {
+                        denom: BLUECHIP_DENOM.to_string(),
+                    },
+                    TokenType::CreatorToken {
+                        contract_addr: creator.clone(),
+                    },
+                ],
+                fully_committed: true,
+                standard: true,
+            },
+            &[],
+            "mock_standard_pool",
+            None,
+        )
+        .unwrap();
+    app.send_tokens(
+        admin.clone(),
+        pool.clone(),
+        &[Coin::new(POOL_RESERVE, BLUECHIP_DENOM)],
+    )
+    .unwrap();
+    app.execute_contract(
+        admin.clone(),
+        creator.clone(),
+        &Cw20ExecuteMsg::Transfer {
+            recipient: pool.to_string(),
+            amount: Uint128::new(POOL_RESERVE),
+        },
+        &[],
+    )
+    .unwrap();
     pool
 }
 
@@ -1234,5 +1306,126 @@ fn apply_with_no_pending_rejected() {
             .to_string()
             .contains("No pending config update"),
         "got: {err}"
+    );
+}
+
+/// Regression for the standard-pool simulation bug: the simulator used
+/// to send `IsFullyCommited` to every hop, but standard pools don't
+/// implement that commit-only query, so any route containing one
+/// errored out. The registry-driven gate must skip the commit check
+/// for `PoolKind::Standard` and the route must simulate AND execute.
+#[test]
+fn simulation_supports_standard_pool_hops() {
+    let mut world = setup_world();
+
+    let bluechip = TokenType::Native {
+        denom: BLUECHIP_DENOM.to_string(),
+    };
+    let creator_std = TokenType::CreatorToken {
+        contract_addr: world.creator_std.clone(),
+    };
+    let route = vec![op(&world.pool_std, bluechip.clone(), creator_std.clone())];
+    let offer_amount = Uint128::new(100_000);
+
+    let sim: SimulateMultiHopResponse = world
+        .app
+        .wrap()
+        .query_wasm_smart(
+            &world.router,
+            &RouterQueryMsg::SimulateMultiHop {
+                operations: route.clone(),
+                offer_amount,
+            },
+        )
+        .expect("standard-pool hop must simulate");
+    assert!(!sim.final_amount.is_zero());
+
+    let before = cw20_balance(&world.app, &world.creator_std, &world.user);
+    world
+        .app
+        .execute_contract(
+            world.user.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ExecuteMultiHop {
+                operations: route,
+                minimum_receive: Uint128::new(1),
+                deadline: None,
+                recipient: None,
+            },
+            &[Coin::new(offer_amount.u128(), BLUECHIP_DENOM)],
+        )
+        .unwrap();
+    let received = cw20_balance(&world.app, &world.creator_std, &world.user) - before;
+    assert_eq!(received, sim.final_amount);
+}
+
+/// Regression for the silent 0.5% per-hop gate: the router must forward
+/// the pools' 5% hard cap as `max_spread` (NOT `None`, which pools
+/// substitute with their 0.5% default) so `minimum_receive` is the
+/// binding slippage control.
+#[test]
+fn router_forwards_hard_cap_max_spread_per_hop() {
+    let mut world = setup_world();
+
+    let bluechip = TokenType::Native {
+        denom: BLUECHIP_DENOM.to_string(),
+    };
+    let creator_a = TokenType::CreatorToken {
+        contract_addr: world.creator_a.clone(),
+    };
+    world
+        .app
+        .execute_contract(
+            world.user.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ExecuteMultiHop {
+                operations: vec![op(&world.pool_a, bluechip.clone(), creator_a.clone())],
+                minimum_receive: Uint128::new(1),
+                deadline: None,
+                recipient: None,
+            },
+            &[Coin::new(100_000u128, BLUECHIP_DENOM)],
+        )
+        .unwrap();
+
+    let forwarded: Option<cosmwasm_std::Decimal> = world
+        .app
+        .wrap()
+        .query_wasm_smart(&world.pool_a, &mock_pool::QueryMsg::LastMaxSpread {})
+        .unwrap();
+    assert_eq!(forwarded, Some(cosmwasm_std::Decimal::percent(5)));
+}
+
+/// Simulation now mirrors execution's registry validation: a route
+/// through an address the factory doesn't know is rejected up front
+/// instead of producing garbage (or a confusing pool-side error).
+#[test]
+fn simulation_rejects_unregistered_pool() {
+    let world = setup_world();
+
+    let bluechip = TokenType::Native {
+        denom: BLUECHIP_DENOM.to_string(),
+    };
+    let creator_a = TokenType::CreatorToken {
+        contract_addr: world.creator_a.clone(),
+    };
+    let err = world
+        .app
+        .wrap()
+        .query_wasm_smart::<SimulateMultiHopResponse>(
+            &world.router,
+            &RouterQueryMsg::SimulateMultiHop {
+                operations: vec![op(
+                    &Addr::unchecked("cosmwasm1notarealpoolnotarealpoolnotareal"),
+                    bluechip,
+                    creator_a,
+                )],
+                offer_amount: Uint128::new(100_000),
+            },
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("not registered"),
+        "expected registry rejection, got: {err}"
     );
 }

--- a/router/src/testing/mock_factory.rs
+++ b/router/src/testing/mock_factory.rs
@@ -26,6 +26,11 @@ use pool_factory_interfaces::{PoolKind, RegisteredPoolResponse};
 pub struct RegistryEntry {
     pub pool_addr: String,
     pub pool_token_info: [TokenType; 2],
+    /// Defaults to Commit (the historical assumption); tests standing up
+    /// standard-pool hops set `Standard` so the router's registry-driven
+    /// commit-status gating can be exercised.
+    #[serde(default)]
+    pub pool_kind: PoolKind,
 }
 
 #[cw_serde]
@@ -41,8 +46,8 @@ pub enum QueryMsg {
     PoolByAddress { pool_addr: String },
 }
 
-/// addr (bech32 string the router passes through) -> canonical pair.
-const POOLS: Map<&str, [TokenType; 2]> = Map::new("pools");
+/// addr (bech32 string the router passes through) -> (canonical pair, kind).
+const POOLS: Map<&str, ([TokenType; 2], PoolKind)> = Map::new("pools");
 
 #[entry_point]
 pub fn instantiate(
@@ -52,7 +57,11 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> StdResult<Response> {
     for entry in msg.pools {
-        POOLS.save(deps.storage, &entry.pool_addr, &entry.pool_token_info)?;
+        POOLS.save(
+            deps.storage,
+            &entry.pool_addr,
+            &(entry.pool_token_info, entry.pool_kind),
+        )?;
     }
     Ok(Response::new())
 }
@@ -78,10 +87,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::PoolByAddress { pool_addr } => {
             let resp = POOLS
                 .may_load(deps.storage, &pool_addr)?
-                .map(|pool_token_info| RegisteredPoolResponse {
+                .map(|(pool_token_info, pool_kind)| RegisteredPoolResponse {
                     pool_id: 0,
                     pool_token_info,
-                    pool_kind: PoolKind::Standard,
+                    pool_kind,
                 });
             to_json_binary(&resp)
         }

--- a/router/src/testing/mock_pool.rs
+++ b/router/src/testing/mock_pool.rs
@@ -26,14 +26,25 @@ use pool_factory_interfaces::asset::{query_pools, PoolPairType, TokenInfo, Token
 pub struct MockPoolState {
     pub asset_infos: [TokenType; 2],
     pub fully_committed: bool,
+    /// Mimic a standard pool: `IsFullyCommited` is a commit-only query,
+    /// so a standard pool rejects it at deserialization. `true` makes
+    /// this mock do the same.
+    #[serde(default)]
+    pub standard: bool,
 }
 
 const STATE: Item<MockPoolState> = Item::new("mock_pool_state");
+
+/// `max_spread` from the most recent swap this mock received — lets
+/// tests assert exactly what the router forwarded per hop.
+const LAST_MAX_SPREAD: Item<Option<Decimal>> = Item::new("last_max_spread");
 
 #[cw_serde]
 pub struct InstantiateMsg {
     pub asset_infos: [TokenType; 2],
     pub fully_committed: bool,
+    #[serde(default)]
+    pub standard: bool,
 }
 
 /// JSON-compatible with `pool_factory_interfaces::routing::PoolSwapExecuteMsg`
@@ -68,6 +79,9 @@ pub enum QueryMsg {
     Pair {},
     Simulation { offer_asset: TokenInfo },
     IsFullyCommited {},
+    /// Test-only introspection: the `max_spread` the router forwarded
+    /// on the most recent swap against this mock.
+    LastMaxSpread {},
 }
 
 #[cw_serde]
@@ -103,6 +117,7 @@ pub fn instantiate(
         &MockPoolState {
             asset_infos: msg.asset_infos,
             fully_committed: msg.fully_committed,
+            standard: msg.standard,
         },
     )?;
     Ok(Response::new())
@@ -112,8 +127,14 @@ pub fn instantiate(
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     match msg {
         ExecuteMsg::SimpleSwap {
-            offer_asset, to, ..
-        } => execute_native_swap(deps, env, info, offer_asset, to),
+            offer_asset,
+            to,
+            max_spread,
+            ..
+        } => {
+            LAST_MAX_SPREAD.save(deps.storage, &max_spread)?;
+            execute_native_swap(deps, env, info, offer_asset, to)
+        }
         ExecuteMsg::Receive(cw20_msg) => execute_cw20_swap(deps, env, info, cw20_msg),
     }
 }
@@ -188,7 +209,8 @@ fn execute_cw20_swap(
     }
 
     let hook: HookMsg = from_json(&cw20_msg.msg)?;
-    let HookMsg::Swap { to, .. } = hook;
+    let HookMsg::Swap { to, max_spread, .. } = hook;
+    LAST_MAX_SPREAD.save(deps.storage, &max_spread)?;
 
     let offer_info = TokenType::CreatorToken {
         contract_addr: info.sender.clone(),
@@ -244,6 +266,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::IsFullyCommited {} => {
             let state = STATE.load(deps.storage)?;
+            // Standard pools don't implement this commit-only query; the
+            // real contract fails variant deserialization. Mirror that.
+            if state.standard {
+                return Err(StdError::generic_err(
+                    "Error parsing into type standard_pool::msg::QueryMsg: unknown variant `is_fully_commited`",
+                ));
+            }
             let status = if state.fully_committed {
                 CommitStatus::FullyCommitted
             } else {
@@ -253,6 +282,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 }
             };
             to_json_binary(&status)
+        }
+        QueryMsg::LastMaxSpread {} => {
+            to_json_binary(&LAST_MAX_SPREAD.may_load(deps.storage)?.flatten())
         }
         QueryMsg::Simulation { offer_asset } => {
             let state = STATE.load(deps.storage)?;


### PR DESCRIPTION
Three router-path bugs found in end-to-end deployment testing:

1. Simulation errored on standard-pool hops: it sent the commit-only IsFullyCommited query to every pool. It now resolves each hop against the factory registry (mirroring execution's validation, and rejecting unregistered pools up front) and only commit pools get the commit-phase check.
2. Pool simulations quoted optimistically: query_simulation and query_reverse_simulation derived reserves from the contract's bank/cw20 BALANCES, which also hold LP fee reserves, the creator fee pot, and commit proceeds. They now quote from POOL_STATE — the exact reserves execution trades against — fixing direct pool quotes and every chained router quote.
3. Every hop silently inherited the pools' 0.5% default max_spread (None is substituted, not disabled), failing thin-pool routes regardless of the caller's minimum_receive. The router now pins each hop to the pools' 5% hard cap so minimum_receive is the binding, end-to-end slippage control the docs promise.

Tests: standard-pool hop simulate+execute, forwarded max_spread assertion via a mock-pool recorder, unregistered-pool rejection, and a reserve-sourcing regression (POOL_STATE diverged from balances).

Ops hardening from the same testing:
- expand-economy rejects instantiation with factory_address equal to the instantiating wallet — the placeholder misconfiguration that deferred every threshold-crossing reward and costs a 48h timelock to repair (tested)
- scripts/verify_deploy.sh: post-deploy wiring verification (expand <-> factory cross-check, expand funding, router factory binding, and the oracle canary with staleness warning)
- keepers: distribution/notify watcher now auto-discovers commit pools from the factory's `pools` registry query when POOL_ADDRESSES is unset; discovery failures keep the last good watch list (tested)
- RUNBOOK.md: production operations guide with timing constants quoted from source (UPDATE_INTERVAL=60s, pool staleness gate=120s, Pyth age cap=300s — keeper cadence 65-75s), the three recurring oracle-pipeline jobs, event-driven duties, deploy order, the fail-closed canary probe, alert list, and reference topology

Workspace suite: 661 tests passing.

https://claude.ai/code/session_01PBHdD9Wpt5rB8eUCWQHzVw