### PR TITLE
Delta security review: document the post-baseline delta, fix 2 findings

### DIFF
--- a/AUDIT_DELTA.md
+++ b/AUDIT_DELTA.md
@@ -1,0 +1,186 @@
+# Delta Security Review — post-baseline changes
+
+**Scope:** all contract-source changes on `claude/loving-albattani-eolo8l`
+relative to merge-base `618fb9d` (the last externally-reviewed baseline;
+see `SECURITY_AUDIT.md` for the full-codebase review that baseline had).
+**Reviewed:** 2026-06-11. **Status of findings: 2 found, 2 fixed in this
+pass** (commit referenced below), each with a regression test.
+
+This is an internal adversarial review of the delta, performed before
+handing the codebase to an external auditor. It is **not** a substitute
+for that audit; its purpose is to make the external pass cheaper and to
+document the reasoning behind every behavioral change since baseline.
+
+## Methodology
+
+- Exact diff enumeration (`git diff 618fb9d..HEAD -- '*.rs'`):
+  10 production source files, 7 test/mock files.
+- Per-hunk adversarial analysis against: authorization, state mutation,
+  panics/DoS in query paths, gas boundedness, wire-format compatibility,
+  arithmetic safety, and economic-incentive changes.
+- Full workspace suite after fixes: **663 tests, 0 failures**; release
+  wasm builds verified for all five contracts; `ci/check_prod_build.py`
+  (feature-clean optimizer builds) passing.
+
+## Change inventory
+
+| # | Change | Files | Risk class |
+|---|--------|-------|-----------|
+| C1 | `CreatorEarnings {}` query (creator-pool) | `creator-pool/src/{msg,query}.rs` | Read-only, additive |
+| C2 | `Pools { start_after, limit }` registry enumeration (factory) | `factory/src/query.rs` | Read-only, additive |
+| C3 | CW20 `marketing` set at token instantiate, admin = pool creator | `factory/src/msg.rs`, `factory/src/execute/pool_lifecycle/create.rs` | Instantiate-path, additive |
+| C4 | `last_committed` serde alias on `LastCommited` query | `creator-pool/src/msg.rs` | Wire, additive |
+| C5 | Simulations quote from `POOL_STATE` accounting reserves | `packages/pool-core/src/query.rs` | **Behavioral** (read path) |
+| C6 | Router simulation: registry-gated per-hop validation | `router/src/simulation.rs` | **Behavioral** (read path) |
+| C7 | Router pins per-hop `max_spread` to the pools' 5% hard cap | `router/src/{execution,msg}.rs` | **Behavioral** (execution) |
+| C8 | expand-economy rejects `factory_address == instantiator` | `expand-economy/src/{contract,error}.rs` | Instantiate-path guard |
+
+## Findings
+
+### DA-1 (Low, FIXED): zero-reserve simulation panicked the query VM
+Introduced by C5. `compute_swap` computes
+`Decimal256::from_ratio(ask_pool, offer_pool)`, which **panics on a zero
+denominator**. After C5, simulations read `POOL_STATE` reserves — which
+are `0/0` on every pre-threshold commit pool — so `simulation` /
+`reverse_simulation` on such a pool aborted with a VM panic instead of a
+decodable error. (Pre-C5, one direction already panicked via zero cw20
+balances; C5 made both directions panic.) No fund risk — queries are
+read-only — and the router path was already protected by its commit-phase
+gate; the exposure was direct integrator queries.
+
+**Fix:** explicit zero-reserve guard in both query functions returning
+`"Pool has no active liquidity to quote against (pre-threshold or
+drained)"`. Regression test:
+`simulation_on_zero_reserves_errors_cleanly_instead_of_panicking`.
+
+### DA-2 (Low, FIXED): `minimum_receive = 0` accepted while per-hop gates widened
+C7 deliberately widens the per-hop spread gate from the pools' 0.5%
+default to their 5% hard cap, making `minimum_receive` the **only**
+end-to-end slippage protection — by design. But the router accepted
+`minimum_receive: 0`, i.e. no protection at all. Pre-C7 such a caller's
+worst-case sandwich extraction was bounded ≈ 0.5%/hop; post-C7 it became
+≈ 5%/hop (≈14% over a 3-hop route). No honest flow wants a zero minimum
+(frontends size it from `SimulateMultiHop`).
+
+**Fix:** `RouterError::ZeroMinimumReceive` rejected at `start_multi_hop`
+— the shared entry covering both the native and CW20 paths. Regression
+test: `router_rejects_zero_minimum_receive` (asserts both paths).
+
+## Per-change analysis
+
+**C1 — CreatorEarnings.** Pure reads of already-public state
+(`CREATOR_FEE_POT`, `CREATOR_EXCESS_POSITION`, threshold flags). All
+loads are `may_load` with defaults except `COMMITFEEINFO`, which is
+unconditionally written at creator-pool instantiate. `claimable_now` is
+computed with the same comparison (`block.time >= unlock_time`) the
+claim handler enforces — no drift between the query's promise and the
+execute path's gate. No authorization needed (nothing secret), no state
+written, gas O(1).
+
+**C2 — Pools enumeration.** Limit clamped to ≤100; iterator is `range
+... .take(limit)` so gas is bounded regardless of registry size;
+`start_after = u64::MAX` yields an empty page; ordering is the Map's
+ascending key order (deterministic). Returns only registry data the
+per-address `PoolByAddress` already exposed.
+
+**C3 — Marketing at instantiate.** Without this, cw20-base permanently
+locks marketing (no admin can ever be set post-instantiate), so every
+creator token would be un-brandable. The factory now passes
+`marketing: Some({ marketing: <pool creator>, .. })`. Reviewed angles:
+the *contract* admin (migration rights) is unchanged (still the
+factory); the marketing admin only controls `UpdateMarketing` /
+`UploadLogo` on the creator's own token; wire-compat with cw20-base ≥
+0.13 confirmed (field exists; `logo: None` valid). Residual note:
+marketing strings/logo URLs are **creator-controlled, untrusted
+display data** — explorers must sanitize (the reference explorer
+sanitizes text and should treat logo URLs as untrusted when rendering
+is added).
+
+**C4 — `last_committed` alias.** Deserialization-only addition;
+canonical (typo'd) name unchanged, so no deployed client breaks.
+`deny_unknown_fields` is unaffected by variant aliases. Round-trip
+covered by `last_commited_query_accepts_both_spellings`.
+
+**C5 — Accounting-reserve quoting.** The economic fix: balances include
+non-AMM funds (LP fee reserves, creator fee pot, commit proceeds,
+emergency escrow), so balance-based quotes overstated depth — measured
+at ~6% optimistic on a freshly-crossed pool in deployment testing.
+Quotes now use the same `POOL_STATE.reserve0/1` the execute path trades
+against; `simulate == execute` is asserted end-to-end by the router's
+`simulate_matches_execute`. Direction mapping (offer↔reserve0/1 by
+`asset_infos` index) mirrors the previous matching logic exactly. See
+DA-1 for the zero-reserve edge this surfaced.
+
+**C6 — Registry-gated simulation.** Simulation previously sent the
+commit-only `IsFullyCommited` to every hop (hard error on standard
+pools). It now (1) resolves each hop via the factory's `PoolByAddress`
+— the same authoritative check execution performs, now also rejecting
+unregistered pools at quote time, strictly earlier and tighter than
+before — and (2) runs the commit-phase check only for
+`PoolKind::Commit`. Legacy registry records deserialize `pool_kind` as
+`Commit` (serde default), which is the historically-correct
+classification, so old pools keep the stricter check. Gas: ≤3 queries
+per hop, hops ≤3. Read-only.
+
+**C7 — Per-hop spread pinned to the hard cap.** A `None` max_spread is
+*substituted* by pools with their 0.5% default — it does not disable
+the gate — which silently failed every thin-pool route regardless of
+the caller's `minimum_receive`, contradicting the router's documented
+slippage model. Pinning `Some(5%)` (the widest value pools accept
+without `allow_high_max_spread`) makes `minimum_receive` binding while
+retaining the pools' own hard cap as defense-in-depth. The forwarded
+value is asserted by `router_forwards_hard_cap_max_spread_per_hop`
+via a mock-pool recorder. The widened unprotected worst case this
+created is closed by DA-2.
+
+**C8 — expand-economy instantiate guard.** Rejects the observed
+deployment footgun (`factory_address` set to the deployer wallet as a
+"placeholder"), which silently defers every threshold-crossing reward
+and costs a 48h timelock to repair. The guard cannot reject a
+legitimate flow: the factory never instantiates expand-economy, and no
+wallet can be the factory contract. Deliberately narrow — a wrong
+*contract* address still passes (caught post-deploy by
+`scripts/verify_deploy.sh`, which cross-checks the wiring in both
+directions).
+
+## Invariants checked across the delta
+
+- No new execute-path authority: the only new execute-side behaviors
+  are two *rejections* (DA-2, C8). No privileged entry points added.
+- No storage-format changes: no migrations required; all wire changes
+  are additive (new query variants, new optional-shaped instantiate
+  field, deserialization alias).
+- All new query paths are gas-bounded (pagination clamps, hop caps) and
+  panic-free (DA-1 closed the one violation).
+- Fund-movement paths (commit, swap, liquidity, claims, distribution)
+  are untouched by this delta except C7's spread-parameter change,
+  whose end-to-end guard is strengthened by DA-2.
+
+## Suggested focus areas for the external audit
+
+1. **C5/C7 economics** — independent confirmation that
+   `POOL_STATE`-based quoting matches execution under concurrent state
+   changes within a block, and that the 5%-per-hop + mandatory
+   `minimum_receive` model has no remaining MEV asymmetry worth
+   tightening (e.g., whether the router should also expose an optional
+   caller-supplied per-hop cap).
+2. **C3 supply-chain** — pin and hash the exact cw20-base wasm the
+   factory's `cw20_token_contract_id` will point at; this review
+   verified wire-compat, not the deployed binary.
+3. **The baseline itself** — this document covers only the delta;
+   `SECURITY_AUDIT.md` plus this file together describe the full
+   surface as of this branch.
+
+## Test evidence
+
+- Workspace: 663 tests / 0 failures (creator-pool 229, factory 254,
+  standard-pool 76, expand-economy 40, pool-core 34, router 23, misc 7).
+- Delta-specific: standard-pool hop simulate+execute, forwarded
+  max_spread assertion, unregistered-pool rejection at quote time,
+  reserve-sourcing regression (POOL_STATE diverged from balances),
+  zero-reserve clean error (DA-1), zero-minimum rejection on both offer
+  paths (DA-2), marketing-admin instantiate assertion, registry
+  pagination (ordering / resume / end-of-data / clamp), both query-name
+  spellings, expand-economy instantiator rejection.
+- Release wasm builds compile for all five contracts;
+  `ci/check_prod_build.py` passes.

--- a/creator-pool/src/testing/query_tests.rs
+++ b/creator-pool/src/testing/query_tests.rs
@@ -740,3 +740,53 @@ fn simulation_prices_against_accounting_reserves_not_balances() {
     assert_eq!(resp.spread_amount, expected_spread);
     assert_eq!(resp.commission_amount, expected_commission);
 }
+
+#[test]
+fn simulation_on_zero_reserves_errors_cleanly_instead_of_panicking() {
+    // Delta-audit regression (DA-1): pre-threshold commit pools have
+    // POOL_STATE reserves of 0/0. compute_swap divides by the offer
+    // reserve, so without the guard the query PANICS (VM error) rather
+    // than returning a decodable error.
+    let mut deps = setup_pool_with_querier();
+    let mut pool_state = crate::state::POOL_STATE.load(&deps.storage).unwrap();
+    pool_state.reserve0 = Uint128::zero();
+    pool_state.reserve1 = Uint128::zero();
+    crate::state::POOL_STATE
+        .save(&mut deps.storage, &pool_state)
+        .unwrap();
+
+    let offer = TokenInfo {
+        info: TokenType::Native {
+            denom: "ubluechip".to_string(),
+        },
+        amount: Uint128::new(1_000_000),
+    };
+    let err = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::Simulation { offer_asset: offer },
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("no active liquidity"),
+        "expected clean zero-liquidity error, got: {err}"
+    );
+
+    let err = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::ReverseSimulation {
+            ask_asset: TokenInfo {
+                info: TokenType::CreatorToken {
+                    contract_addr: Addr::unchecked("token_contract"),
+                },
+                amount: Uint128::new(1_000_000),
+            },
+        },
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("no active liquidity"),
+        "expected clean zero-liquidity error, got: {err}"
+    );
+}

--- a/packages/pool-core/src/query.rs
+++ b/packages/pool-core/src/query.rs
@@ -64,6 +64,15 @@ pub fn query_simulation(deps: Deps, offer_asset: TokenInfo) -> StdResult<Simulat
         ));
     };
 
+    // Zero accounting reserves (pre-threshold commit pool, or a drained
+    // pool) must return a clean error: `compute_swap` divides by the
+    // offer reserve and would otherwise panic the query.
+    if offer_reserve.is_zero() || ask_reserve.is_zero() {
+        return Err(StdError::generic_err(
+            "Pool has no active liquidity to quote against (pre-threshold or drained)",
+        ));
+    }
+
     let (return_amount, spread_amount, commission_amount) = compute_swap(
         offer_reserve,
         ask_reserve,
@@ -98,6 +107,13 @@ pub fn query_reverse_simulation(
             "Given ask asset doesn't belong to pairs",
         ));
     };
+
+    // Same zero-reserve guard as `query_simulation`.
+    if offer_reserve.is_zero() || ask_reserve.is_zero() {
+        return Err(StdError::generic_err(
+            "Pool has no active liquidity to quote against (pre-threshold or drained)",
+        ));
+    }
 
     let (offer_amount, spread_amount, commission_amount) = compute_offer_amount(
         offer_reserve,

--- a/router/src/error.rs
+++ b/router/src/error.rs
@@ -28,6 +28,13 @@ pub enum RouterError {
     #[error("Offer amount must be greater than zero")]
     ZeroAmount,
 
+    #[error(
+        "minimum_receive must be greater than zero — it is the route's only \
+         end-to-end slippage protection (per-hop gates are pinned to the pools' \
+         5% hard cap). Size it from SimulateMultiHop"
+    )]
+    ZeroMinimumReceive,
+
     #[error("Route input and final output must differ")]
     SameInputOutput,
 

--- a/router/src/execution.rs
+++ b/router/src/execution.rs
@@ -162,6 +162,15 @@ fn start_multi_hop(
     if offer_amount.is_zero() {
         return Err(RouterError::ZeroAmount);
     }
+    // Delta-audit hardening (DA-2): with per-hop max_spread pinned to the
+    // pools' 5% hard cap, minimum_receive is the ONLY end-to-end slippage
+    // guard. Zero means a 3-hop route could be sandwiched for up to ~14%
+    // with no recourse; no retail flow ever wants that, and frontends
+    // size it from SimulateMultiHop. Fail closed at the shared entry
+    // point (covers both the native and CW20 paths).
+    if minimum_receive.is_zero() {
+        return Err(RouterError::ZeroMinimumReceive);
+    }
     if let Some(d) = deadline {
         if env.block.time > d {
             return Err(RouterError::DeadlineExceeded {

--- a/router/src/testing/integration_tests.rs
+++ b/router/src/testing/integration_tests.rs
@@ -1429,3 +1429,60 @@ fn simulation_rejects_unregistered_pool() {
         "expected registry rejection, got: {err}"
     );
 }
+
+/// Delta-audit hardening (DA-2): minimum_receive is the only end-to-end
+/// slippage protection (per-hop gates are pinned to the pools' 5% hard
+/// cap), so a zero value — i.e. no protection at all — is rejected at
+/// the shared entry point on both offer paths.
+#[test]
+fn router_rejects_zero_minimum_receive() {
+    let mut world = setup_world();
+
+    let bluechip = TokenType::Native {
+        denom: BLUECHIP_DENOM.to_string(),
+    };
+    let creator_a = TokenType::CreatorToken {
+        contract_addr: world.creator_a.clone(),
+    };
+
+    // Native-offered path.
+    let err = world
+        .app
+        .execute_contract(
+            world.user.clone(),
+            world.router.clone(),
+            &RouterExecuteMsg::ExecuteMultiHop {
+                operations: vec![op(&world.pool_a, bluechip.clone(), creator_a.clone())],
+                minimum_receive: Uint128::zero(),
+                deadline: None,
+                recipient: None,
+            },
+            &[Coin::new(100_000u128, BLUECHIP_DENOM)],
+        )
+        .unwrap_err();
+    assert!(
+        err.root_cause().to_string().contains("minimum_receive"),
+        "expected zero-minimum rejection, got: {err:?}"
+    );
+
+    // CW20-offered path goes through the same shared gate.
+    let send_msg = Cw20ExecuteMsg::Send {
+        contract: world.router.to_string(),
+        amount: Uint128::new(100_000),
+        msg: to_json_binary(&Cw20HookMsg::ExecuteMultiHop {
+            operations: vec![op(&world.pool_a, creator_a, bluechip)],
+            minimum_receive: Uint128::zero(),
+            deadline: None,
+            recipient: None,
+        })
+        .unwrap(),
+    };
+    let err = world
+        .app
+        .execute_contract(world.user.clone(), world.creator_a.clone(), &send_msg, &[])
+        .unwrap_err();
+    assert!(
+        err.root_cause().to_string().contains("minimum_receive"),
+        "expected zero-minimum rejection on cw20 path, got: {err:?}"
+    );
+}


### PR DESCRIPTION
AUDIT_DELTA.md is the internal adversarial review of every contract change since the audited baseline (618fb9d), written to hand to the external auditor: per-change security analysis, invariants checked, test evidence, and suggested external focus areas.

Two findings, both Low, both fixed here with regression tests:

DA-1: simulations on zero-reserve pools panicked the query VM. Quoting from POOL_STATE (the earlier optimistic-quote fix) exposed compute_swap's Decimal256::from_ratio division by a zero offer reserve on pre-threshold commit pools (reserves 0/0). Both query_simulation and query_reverse_simulation now return a clean "no active liquidity" error instead.

DA-2: the router accepted minimum_receive = 0. With per-hop max_spread now pinned to the pools' 5% hard cap, minimum_receive is the only end-to-end slippage protection, and zero meant none at all (~14% worst case over 3 hops vs ~1.5% before the cap change). The shared start_multi_hop entry now rejects zero on both the native and CW20 paths.

Workspace suite after fixes: 663 tests, 0 failures.

https://claude.ai/code/session_01PBHdD9Wpt5rB8eUCWQHzVw