### PR TITLE
Correct integration docs and keeper poll default (audit F-8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1018,7 +1018,7 @@ bluechip-contracts/
 └── frontend/                         # Reference UI
 ```
 
-See `FUZZING.md` for the fuzz harness layout and `FUZZ_REVIEW.md` for the latest coverage review.
+See `FUZZING.md` for the fuzz harness layout and coverage notes.
 
 ### Deployment Order
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -46,7 +46,7 @@ Low / Informational or by-design economic decisions.
 | F-5 | Low | oracle | `UpdateOraclePrice` 60s cooldown is bypassed during the post-reset buffer (`last_update` stays 0). **Open.** |
 | F-6 | Low | creator-pool | Oracle staleness gate fail-opens when the factory returns `timestamp == 0`. **Open.** |
 | F-7 | Low | pool-core | `Simulation` / `CumulativePrices` queries price against live balances, not tracked reserves. **Open.** |
-| F-8 | Low (ops) | keepers | Default `ORACLE_POLL_INTERVAL_MS=330s` contradicts the on-chain 120s staleness gate. **Open.** |
+| F-8 | Low (ops) | keepers | Default `ORACLE_POLL_INTERVAL_MS=330s` contradicts the on-chain 120s staleness gate. **Fixed** (default lowered to 70s). |
 | F-9 | Low–Med | pool-core | First deposit with a highly asymmetric ratio could leave one reserve below `MINIMUM_LIQUIDITY` (found via the stateful fuzz harness; pre-existing). **Fixed.** |
 | — | Info | various | Dead ungated oracle getters; doc/const mismatches; unbounded never-pruned maps; broken `optimize-pool` Makefile target; stale committed `*.wasm` blobs; "expand-economy" disburses from a pre-funded reservoir (not a literal mint). |
 
@@ -161,10 +161,12 @@ reserves and is unaffected. **Action:** use `POOL_STATE.reserve*` in these
 handlers.
 
 ### F-8 — Keeper default poll interval contradicts the staleness gate
-`keepers/src/lib/config.ts`. `ORACLE_POLL_INTERVAL_MS` defaults to 330s
+`keepers/src/lib/config.ts`. `ORACLE_POLL_INTERVAL_MS` defaulted to 330s
 (sized for the retired 300s on-chain interval), but the pool-side staleness
-gate is 120s. Default-configured keepers leave commit valuations stale-blocked
+gate is 120s. Default-configured keepers left commit valuations stale-blocked
 for most of each cycle. **Action:** lower the default to ≤90s.
+**Resolution:** default lowered to 70s (matching RUNBOOK's 65-75s cadence);
+`.env.example` and README updated to match.
 
 ---
 

--- a/docs/FRONTEND_MIGRATION.md
+++ b/docs/FRONTEND_MIGRATION.md
@@ -1800,7 +1800,7 @@ Every commit emits a `wasm` event with these attributes:
 | Attribute | Value |
 |-----------|-------|
 | `action` | `"commit"` |
-| `phase` | `"funding"` \| `"post-threshold"` \| `"threshold-crossing"` \| `"threshold-hit-exact"` |
+| `phase` | `"funding"` (pre-threshold) \| `"active"` (post-threshold) \| `"threshold_crossing"` \| `"threshold_hit_exact"` |
 | `committer` | wallet address that committed |
 | `commit_amount_bluechip` / `commit_amount_usd` | amounts in micro-units |
 | `total_commit_count` | running commit counter for the pool |

--- a/keepers/.env.example
+++ b/keepers/.env.example
@@ -7,7 +7,7 @@
 
 # Chain connection
 RPC_ENDPOINT=https://rpc.bluechip-mainnet.example:443
-CHAIN_ID=bluechip-1
+CHAIN_ID=bluechip-3
 BECH32_PREFIX=bluechip
 
 # Gas settings (tune to your chain's gas price schedule)
@@ -29,15 +29,17 @@ KEEPER_MNEMONIC="twelve words of your keeper mnemonic here ..."
 # Optional tuning (defaults shown)
 # ---------------------------------------------------------------------------
 
-# Oracle keeper polling. Defaults to 5.5 min so we check slightly after
-# each 5-min factory cooldown window.
-# ORACLE_POLL_INTERVAL_MS=330000
+# Oracle keeper polling. Defaults to 70 s: the factory publishes at most
+# once per 60 s (UPDATE_INTERVAL) and pool swaps revert once the price is
+# older than 120 s (MAX_ORACLE_STALENESS_SECONDS), so poll just after each
+# update window opens. See RUNBOOK.md ("65-75 s cadence").
+# ORACLE_POLL_INTERVAL_MS=70000
 
 # Rate-limit prune sweep cadence (folded into the oracle keeper).
 # Once every N oracle iterations the keeper also dispatches
-# factory.PruneRateLimits {}. Default 200 × 5.5min ≈ 18h, so the sweep
+# factory.PruneRateLimits {}. Default 750 × 70s ≈ 14.5h, so the sweep
 # fires roughly daily per process. Set to 0 to disable entirely.
-# ORACLE_PRUNE_EVERY_N=200
+# ORACLE_PRUNE_EVERY_N=750
 
 # Per-call work cap passed to PruneRateLimits. Contract enforces a
 # hard ceiling of 500; default 100 is plenty for the steady-state

--- a/keepers/README.md
+++ b/keepers/README.md
@@ -125,7 +125,7 @@ every ORACLE_POLL_INTERVAL_MS (default 70 s — tracks the on-chain
   warn if wallet balance < MIN_KEEPER_BALANCE_UBLUECHIP
 
   # Folded-in maintenance sweep — see "Rate-limit prune" below.
-  every ORACLE_PRUNE_EVERY_N iterations (default 200 ≈ once per 18h):
+  every ORACLE_PRUNE_EVERY_N iterations (default 750 ≈ once per 14.5h):
     submit factory.PruneRateLimits { batch_size: PRUNE_BATCH_SIZE }
 ```
 

--- a/keepers/src/__tests__/config.test.ts
+++ b/keepers/src/__tests__/config.test.ts
@@ -17,7 +17,7 @@ describe("parseConfig", () => {
     const cfg = parseConfig(BASE_ENV);
     expect(cfg.RPC_ENDPOINT).toBe("http://localhost:26657");
     expect(cfg.GAS_PRICE).toBe("0.025ubluechip"); // default
-    expect(cfg.ORACLE_POLL_INTERVAL_MS).toBe(330_000); // default
+    expect(cfg.ORACLE_POLL_INTERVAL_MS).toBe(70_000); // default
   });
 
   it("rejects missing required fields", () => {

--- a/keepers/src/lib/config.ts
+++ b/keepers/src/lib/config.ts
@@ -77,16 +77,20 @@ export const ConfigSchema = z.object({
   // Wallet
   KEEPER_MNEMONIC: nonEmptyString,
 
-  // Oracle keeper tuning
-  ORACLE_POLL_INTERVAL_MS: positiveIntString({ default: "330000" }), // 5.5 min
+  // Oracle keeper tuning. 70s tracks the on-chain UPDATE_INTERVAL (60s,
+  // factory/src/internal_bluechip_price_oracle.rs) with headroom, and
+  // stays well inside the pool-side 120s staleness gate
+  // (MAX_ORACLE_STALENESS_SECONDS, creator-pool/src/swap_helper.rs).
+  // See RUNBOOK.md ("65-75s cadence") and SECURITY_AUDIT.md F-8.
+  ORACLE_POLL_INTERVAL_MS: positiveIntString({ default: "70000" }), // 70 s
 
   // Rate-limit prune sweep cadence (folded into the oracle keeper).
   // Once every N oracle iterations the keeper also dispatches
-  // factory.PruneRateLimits {}. Default 200 × 5.5min ≈ 18h, so the
+  // factory.PruneRateLimits {}. Default 750 × 70s ≈ 14.5h, so the
   // sweep runs roughly daily per process. Set to 0 to disable
   // entirely (e.g., for testnets where rate-limit growth doesn't
   // matter or for ops who'd rather run prune as a separate cron).
-  ORACLE_PRUNE_EVERY_N: positiveIntString({ allowZero: true, default: "200" }),
+  ORACLE_PRUNE_EVERY_N: positiveIntString({ allowZero: true, default: "750" }),
   // Per-call work cap passed to PruneRateLimits. Contract enforces a
   // hard ceiling of 500; we default to 100 which is plenty for the
   // expected drift rate (≪ 100 stale entries per day on a healthy

--- a/osmo_testnet.env
+++ b/osmo_testnet.env
@@ -51,8 +51,9 @@ PYTH_OSMO_USD_FEED_ID="d9437c194a4b00ba9d7652cd9af3905e73ee15a2ca4152ac1f8d430cc
 HERMES_ENDPOINT="https://hermes-beta.pyth.network"
 
 # Cadence the VAA pusher runs at. Must be < MAX_PRICE_AGE_SECONDS_BEFORE_STALE
-# (90s) to keep Pyth state fresh; 30s leaves comfortable headroom and
-# matches the keeper UpdateOraclePrice cooldown behaviour.
+# (300s, factory/src/state.rs) to keep Pyth state fresh; 30s leaves
+# comfortable headroom and matches the keeper UpdateOraclePrice cooldown
+# behaviour.
 VAA_PUSH_INTERVAL_SECONDS="30"
 
 # ---- Wasm artifacts ----


### PR DESCRIPTION
- FRONTEND_MIGRATION: document the commit event's real phase values (funding | active | threshold_crossing | threshold_hit_exact); the hyphenated names in the event-watch table never matched what creator-pool emits.
- keepers: lower ORACLE_POLL_INTERVAL_MS default from 330s to 70s so default-configured keepers keep the factory price inside the 120s pool-side staleness gate (SECURITY_AUDIT F-8, RUNBOOK 65-75s cadence); scale ORACLE_PRUNE_EVERY_N to 750 to keep the prune sweep ~daily. Update .env.example, README, and config test; mark F-8 fixed.
- .env.example: align the example CHAIN_ID with bluechip-3 used by the frontend/explorer configs.
- osmo_testnet.env: the VAA-pusher comment cited a 90s staleness bound; MAX_PRICE_AGE_SECONDS_BEFORE_STALE is 300s.
- README: drop the reference to FUZZ_REVIEW.md, which is not in the repo.


Claude-Session: https://claude.ai/code/session_013UWKkumZFgbH5AZpbH5XWy