### PR TITLE
Remove audit-finding references from code comments

### DIFF
--- a/creator-pool/src/testing/query_tests.rs
+++ b/creator-pool/src/testing/query_tests.rs
@@ -743,10 +743,9 @@ fn simulation_prices_against_accounting_reserves_not_balances() {
 
 #[test]
 fn simulation_on_zero_reserves_errors_cleanly_instead_of_panicking() {
-    // Delta-audit regression (DA-1): pre-threshold commit pools have
-    // POOL_STATE reserves of 0/0. compute_swap divides by the offer
-    // reserve, so without the guard the query PANICS (VM error) rather
-    // than returning a decodable error.
+    // Pre-threshold commit pools have POOL_STATE reserves of 0/0.
+    // compute_swap divides by the offer reserve, so without the guard the
+    // query PANICS (VM error) rather than returning a decodable error.
     let mut deps = setup_pool_with_querier();
     let mut pool_state = crate::state::POOL_STATE.load(&deps.storage).unwrap();
     pool_state.reserve0 = Uint128::zero();

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -284,7 +284,7 @@ const PortfolioPage: React.FC = () => {
         }
     }, [client, address]);
 
-    // Fetch liquidity positions across all known pools using positions_by_owner query (H-5 audit optimization)
+    // Fetch liquidity positions across all known pools using positions_by_owner query
     const fetchPositions = useCallback(async () => {
         if (!client || !address) return;
 

--- a/keepers/src/lib/types.ts
+++ b/keepers/src/lib/types.ts
@@ -17,7 +17,7 @@ export const PoolExecContinueDistribution = { continue_distribution: {} } as con
  */
 export const PoolExecRetryFactoryNotify = { retry_factory_notify: {} } as const;
 /**
- * Factory-side storage hygiene (HIGH-2 audit follow-up). Iterates the
+ * Factory-side storage hygiene. Iterates the
  * per-address rate-limit maps and removes entries older than 10× the
  * cooldown window. `batch_size` caps work per call (default 100, hard
  * cap 500 on the contract side) so a large backlog doesn't exceed

--- a/router/src/execution.rs
+++ b/router/src/execution.rs
@@ -162,12 +162,12 @@ fn start_multi_hop(
     if offer_amount.is_zero() {
         return Err(RouterError::ZeroAmount);
     }
-    // Delta-audit hardening (DA-2): with per-hop max_spread pinned to the
-    // pools' 5% hard cap, minimum_receive is the ONLY end-to-end slippage
-    // guard. Zero means a 3-hop route could be sandwiched for up to ~14%
-    // with no recourse; no retail flow ever wants that, and frontends
-    // size it from SimulateMultiHop. Fail closed at the shared entry
-    // point (covers both the native and CW20 paths).
+    // With per-hop max_spread pinned to the pools' 5% hard cap,
+    // minimum_receive is the ONLY end-to-end slippage guard. Zero means a
+    // 3-hop route could be sandwiched for up to ~14% with no recourse; no
+    // retail flow ever wants that, and frontends size it from
+    // SimulateMultiHop. Fail closed at the shared entry point (covers both
+    // the native and CW20 paths).
     if minimum_receive.is_zero() {
         return Err(RouterError::ZeroMinimumReceive);
     }

--- a/router/src/testing/integration_tests.rs
+++ b/router/src/testing/integration_tests.rs
@@ -1430,10 +1430,10 @@ fn simulation_rejects_unregistered_pool() {
     );
 }
 
-/// Delta-audit hardening (DA-2): minimum_receive is the only end-to-end
-/// slippage protection (per-hop gates are pinned to the pools' 5% hard
-/// cap), so a zero value — i.e. no protection at all — is rejected at
-/// the shared entry point on both offer paths.
+/// minimum_receive is the only end-to-end slippage protection (per-hop
+/// gates are pinned to the pools' 5% hard cap), so a zero value — i.e.
+/// no protection at all — is rejected at the shared entry point on both
+/// offer paths.
 #[test]
 fn router_rejects_zero_minimum_receive() {
     let mut world = setup_world();

--- a/standard-pool/src/testing/balance_verify.rs
+++ b/standard-pool/src/testing/balance_verify.rs
@@ -365,18 +365,8 @@ fn reply_propagates_query_failure_on_missing_cw20() {
     assert!(!err.to_string().is_empty());
 }
 
-/// Regression for Finding 12.1 — `AddToPosition` with prior CW20-side
-/// fee accrual must NOT trip the balance-verify reply.
-///
-/// Pre-fix, the verify reply enforced `delta == actual_amount`. On
-/// `add_to_position` with non-zero `fees_owed_1`, the LAST message in
-/// the Response was the CW20 fee transfer OUT (after the TransferFrom
-/// in). Post-balance reflected `pre + deposited - fee_out`, so
-/// `delta = deposited - fee_out != deposited`, and the reply rejected
-/// every add-to-position whose position had any prior CW20-side fee
-/// accrual.
-///
-/// Post-fix: the reply enforces
+/// `AddToPosition` with prior CW20-side fee accrual must NOT trip the
+/// balance-verify reply. The reply enforces
 /// `post + outgoing == pre + actual_amount`. With `outgoing = fee_out`,
 /// the invariant holds exactly when the CW20 behaves honestly. This
 /// test exercises the reply directly against a context that mirrors

--- a/standard-pool/src/testing/deposit_liquidity.rs
+++ b/standard-pool/src/testing/deposit_liquidity.rs
@@ -234,7 +234,7 @@ fn deposit_rejects_zero_side_for_initial() {
 
 #[test]
 fn first_deposit_rejects_subfloor_reserve_side() {
-    // F-9 regression: an asymmetric first deposit whose geometric mean
+    // An asymmetric first deposit whose geometric mean
     // clears MINIMUM_LIQUIDITY but whose smaller side is below it must be
     // rejected. sqrt(20 * 5e8) = 100_000 passes the geometric-mean check,
     // yet reserve0 would be left at 20 — under the floor the swap path and


### PR DESCRIPTION
Strip audit-finding identifiers and audit-specific framing from code comments while preserving the surrounding functional documentation. No code or behavior changes.


Claude-Session: https://claude.ai/code/session_011YkUH4eobEVnQq9FDPRrnH